### PR TITLE
Fix rake assets:precompile

### DIFF
--- a/config/initializers/jasmine_rails.rb
+++ b/config/initializers/jasmine_rails.rb
@@ -1,9 +1,11 @@
-module JasmineRails
-  class ApplicationController < ActionController::Base
-    before_filter :skip_slimmer
+if defined?(JasmineRails)
+  module JasmineRails
+    class ApplicationController < ActionController::Base
+      before_filter :skip_slimmer
 
-    def skip_slimmer
-      response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+      def skip_slimmer
+        response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+      end
     end
   end
 end


### PR DESCRIPTION
When compiling assets the jasmine gem isn't defined because we
specifically activate only the 'assets' gem group.

The routes file tries to avoid mixing in the jasmine routes in this
case, but this initializer causes the JasmineRails module to be always
defined even when the jasmine gem isn't loaded.

This changes the initializer to avoid defining the JasminRails module if
it's not already defined.
