### PR TITLE
Scroll contents with page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 group :assets do
   gem 'sass-rails', '~> 4.0.0'
   gem 'uglifier', '>= 1.3.0'
-  gem 'govuk_frontend_toolkit', '0.44.0'
+  gem 'govuk_frontend_toolkit', '0.45.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       rest-client (~> 1.6.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    govuk_frontend_toolkit (0.44.0)
+    govuk_frontend_toolkit (0.45.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -190,7 +190,7 @@ DEPENDENCIES
   debugger
   exception_notification (= 4.0.1)
   gds-api-adapters (= 8.2.3)
-  govuk_frontend_toolkit (= 0.44.0)
+  govuk_frontend_toolkit (= 0.45.0)
   jasmine-rails
   plek (= 1.3.0)
   rails (= 4.0.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,4 +3,5 @@
 
 $(function(){
   GOVUK.primaryLinks.init('.primary-item');
+  GOVUK.stickAtTopWhenScrolling.init();
 });

--- a/app/assets/stylesheets/_stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/_stick-at-top-when-scrolling.scss
@@ -1,0 +1,7 @@
+.content-fixed {
+  position: fixed;
+  top: 0;
+}
+.shim {
+  display: block;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 
 @import "reset";
 @import "govspeak";
+@import "stick-at-top-when-scrolling";
 
 #wrapper {
   display: block;
@@ -101,17 +102,18 @@
     }
   }
   
-  nav {
-    list-style: none;
-    @include core-16;
-    padding-bottom: $gutter;
-    
+  .sidebar {
     @include media(tablet){
       width: $one-third;
       float: left;
       padding-bottom: $gutter*2;
     }
 
+    ol {
+      list-style: none;
+      @include core-16;
+      padding-bottom: $gutter;
+    }
     a {
       text-decoration: none;
     }
@@ -147,6 +149,8 @@
     }
   }
   footer {
+    clear: both;
+
     dt {
       @include core-14;
       padding-top:20px;
@@ -171,7 +175,7 @@
       @include media(tablet){
         float: left;
         width: $one-third;
-      } 
+      }
     }
   }
 }

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -37,8 +37,8 @@
   </div>
 </header>
 
-<nav>
-  <ol class="inner-block">
+<nav class="sidebar">
+  <ol class="inner-block js-stick-at-top-when-scrolling">
     <%= render 'nav_item', headings: @document.details['headers'] %>
   </ol>
 </nav>
@@ -51,7 +51,7 @@
   </div>
 </div>
 
-<footer>
+<footer class="js-footer">
   <div class='history'>
     <div class="inner-block">
       <dl>


### PR DESCRIPTION
Use the stickAtTopWhenScrolling JavaScript from the frontend_toolkit to
make the contents stick when you scroll.

Added a `js-footer` class to the footer to stop the contents from
scrolling over the footer. Added the sticky styles.

https://www.pivotaltracker.com/story/show/67825962
