### PR TITLE
Remove links from show page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,7 @@
   display: block;
   text-align: center;
   padding-bottom: $gutter;
-  
+
   @include media(desktop) {
     padding-bottom: $gutter*2;
   }
@@ -45,12 +45,12 @@
   header {
     @extend %contain-floats;
     padding: $gutter-half 0;
-    
+
     @include media(tablet){
       padding: $gutter*2 0 $gutter*2;
     }
 
-    .category a{
+    .category {
       @include core-24;
       text-decoration:none;
     }
@@ -94,14 +94,14 @@
       @include core-19;
       clear:both;
       padding: $gutter/2 0 0;
-      
+
       @include media(tablet){
         @include core-24;
         padding: $gutter 0 0;
       }
     }
   }
-  
+
   .sidebar {
     @include media(tablet){
       width: $one-third;
@@ -157,7 +157,7 @@
     }
     dd {
       @include bold-24;
-      
+
       ul {
         list-style: none;
       }

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, [@document.title, "Competition & Markets Authority case"].join(' ') %>
 <header>
   <div class="inner-block">
-    <span class="category"><a href=''>Competition &amp; Markets Authority case</a></span>
+    <span class="category">Competition &amp; Markets Authority case</span>
     <h1><%= @document.title %></h1>
   </div>
   <div class="metadata">
@@ -17,13 +17,13 @@
       </dd>
 
       <dt>Sector:</dt>
-      <dd><a href="#"><%= @document.details.market_sector %></a></dd>
+      <dd><%= @document.details.market_sector %></dd>
 
       <dt>Case type:</dt>
-      <dd><a href="#"><%= @document.details.case_type unless @document.details.empty? %></a></dd>
+      <dd><%= @document.details.case_type unless @document.details.empty? %></dd>
 
       <dt>Case state:</dt>
-      <dd><a href="#"><%= @document.details.case_state.capitalize unless @document.details.empty? %></a></dd>
+      <dd><%= @document.details.case_state.capitalize unless @document.details.empty? %></dd>
 
       <dt>Outcome type:</dt>
       <dd><%= @document.details.outcome_type.capitalize unless @document.details.empty? %></dd>
@@ -70,13 +70,13 @@
   <div class='links'>
     <dl class='inner-block'>
       <dt>Sector:</dt>
-      <dd><a href="#"><%= @document.details.market_sector %></a></dd>
+      <dd><%= @document.details.market_sector %></dd>
 
       <dt>Case type:</dt>
-      <dd><a href="#"><%= @document.details.case_type %></a></dd>
+      <dd><%= @document.details.case_type %></dd>
 
       <dt>Case state:</dt>
-      <dd><a href="#"><%= @document.details.case_state.capitalize %></a></dd>
+      <dd><%= @document.details.case_state.capitalize %></dd>
 
       <dt>Outcome type:</dt>
       <dd><%= @document.details.outcome_type.capitalize %></dd>


### PR DESCRIPTION
Unlinking the metadata here so the app can stand by itself.
The stylesheet changes also include one-off whitespace fixes because guess who has two thumbs and has now fixed their textmate config.
