### PR TITLE
Format documents according to Finder API schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '4.0.2'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '8.2.3'
+  gem 'gds-api-adapters', '10.6.1'
 end
 
 gem 'exception_notification', '4.0.1'
@@ -30,4 +30,5 @@ end
 group :development, :test do
   gem 'debugger'
   gem 'jasmine-rails'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.0)
     columnize (0.3.6)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
@@ -67,7 +68,7 @@ GEM
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
     execjs (2.0.2)
-    gds-api-adapters (8.2.3)
+    gds-api-adapters (10.6.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -97,6 +98,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.8.4)
@@ -107,6 +109,10 @@ GEM
     plek (1.3.0)
       builder
     polyglot (0.3.3)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -153,6 +159,7 @@ GEM
       plek (>= 0.1.8)
       rack (>= 1.3.5)
       rest-client
+    slop (3.4.7)
     sprockets (2.10.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -192,11 +199,12 @@ DEPENDENCIES
   cucumber-rails (= 1.4.0)
   debugger
   exception_notification (= 4.0.1)
-  gds-api-adapters (= 8.2.3)
+  gds-api-adapters (= 10.6.1)
   govuk_frontend_toolkit (= 0.45.0)
   jasmine-rails
   logstasher (= 0.4.8)
   plek (= 1.3.0)
+  pry
   rails (= 4.0.2)
   rspec-rails (= 2.14.1)
   sass-rails (~> 4.0.0)

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -7,7 +7,13 @@ class SpecialistDocumentsController < ApplicationController
     artefact = content_api.artefact(params[:path])
     error_not_found unless artefact
 
-    @document = DocumentPresenter.new(artefact)
+    @document = DocumentPresenter.new(schema, artefact)
+  end
+
+  private
+
+  def schema
+    finder_api.get_schema("cma-cases")
   end
 
   def error_not_found

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,12 +1,23 @@
 class DocumentPresenter
 
-  attr_reader :document
+  attr_reader :document, :schema
+  private :document, :schema
 
   delegate :title, :details, :updated_at, to: :document
 
-  delegate :opened_date, :closed_date, :market_sector, :case_type, :case_state, :outcome_type, :summary, :headers, :body, to: :"document.details"
+  delegate :opened_date,
+    :closed_date,
+    :market_sector,
+    :case_type,
+    :case_state,
+    :outcome_type,
+    :summary,
+    :headers,
+    :body,
+    to: :"document.details"
 
-  def initialize(document)
+  def initialize(schema, document)
+    @schema = schema
     @document = document
   end
 
@@ -21,14 +32,17 @@ class DocumentPresenter
   end
 
   def metadata
-    metadata = {
-      "Market sector" => market_sector,
-      "Case type" => case_type,
-      "Case state" => case_state.capitalize,
-      "Outcome type" => outcome_type,
-    }
-
-    metadata.reject { |_, value| value.blank? }
+    schema.user_friendly_values(raw_metadata)
   end
 
+  private
+
+  def raw_metadata
+    {
+      case_type: case_type,
+      case_state: case_state,
+      market_sector: market_sector,
+      outcome_type: outcome_type,
+    }.reject { |_, value| value.blank? }
+  end
 end

--- a/features/step_definitions/case_steps.rb
+++ b/features/step_definitions/case_steps.rb
@@ -19,12 +19,14 @@ Given(/^a published case$/) do
       "case_type" => "regulatory-references-and-appeals",
       "case_state" => "closed",
       "market_sector" => "distribution-and-service-industries",
-      "outcome_type" => "undertakings-in-lieu-of-reference",
+      "outcome_type" => "markets-phase-1-undertakings-in-lieu-of-reference",
       "headers" => []
     }
   )
 
   content_api_has_an_artefact(@slug, artefact)
+
+  finder_api_has_schema("cma-cases")
 end
 
 When(/^I visit the case page$/) do

--- a/features/support/finder_api.rb
+++ b/features/support/finder_api.rb
@@ -1,0 +1,3 @@
+require 'gds_api/test_helpers/finder_api'
+
+World(GdsApi::TestHelpers::FinderApi)


### PR DESCRIPTION
Resolves the hyphenated labelling issue, Market sector:recreation-and-leisure,  Case type:consumer-enforcement etc.
