### PR TITLE
Use tags for organisation

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -21,6 +21,10 @@ class DocumentPresenter
     @document = document
   end
 
+  def format_name
+    "Competition and Markets Authority case"
+  end
+
   def date_metadata
     date_metadata = {
       "Opened date" => opened_date,

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, [@document.title, "Competition & Markets Authority case"].join(' ') %>
+<% content_for :page_title, [@document.title, @document.format_name].join(' ') %>
 <header>
   <div class="inner-block">
-    <span class="category">Competition &amp; Markets Authority case</span>
+    <span class="category"><%= @document.format_name %></span>
     <h1><%= @document.title %></h1>
   </div>
   <div class="metadata">


### PR DESCRIPTION
Current case is that there will only be one organisation associated with a document, so primary_tag just returns the first. If this changes we'll need a way to mark an org as primary.
- Update presenter with tags/organisations
- Update tests
- Update view

Trello: https://trello.com/c/y41PIOlq/153-aaib-finder-viewing-reports-on-gov-uk-3
