### PR TITLE
Remove double top colour bar

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,19 +19,6 @@
     padding-bottom: $gutter*2;
   }
 
-  .top-colour-bar {
-    border-top: $gutter-one-third solid $govuk-blue;
-    max-width: 960px;
-    margin: 0 $gutter-half;
-
-    @include media(tablet){
-      margin: 0 $gutter;
-    }
-    @include media($min-width: 960px + $gutter*2){
-      margin: 0 auto;
-    }
-  }
-
   #page {
     text-align: left;
     display: block;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,6 @@
   <body>
     <div id="global-breadcrumb" class="header-context"></div>
     <main id="wrapper" role="main">
-      <div class="top-colour-bar"></div>
       <div id="page">
         <%= yield %>
       </div>


### PR DESCRIPTION
This commit removes the .top-colour-bar which was being doubled up now that this was also coming from the govuk_template.
