### PR TITLE
Fix headers method to return headers

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -24,7 +24,7 @@ class DocumentPresenter
   end
 
   def headers
-    document.details || []
+    document.details.headers || []
   end
 
 private

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -1,7 +1,7 @@
-  require "ostruct"
+require "ostruct"
 require "spec_helper"
 
-describe CmaCasePresenter do
+describe DocumentPresenter do
 
   subject(:presenter) {
     Class.new(DocumentPresenter) {
@@ -80,6 +80,19 @@ describe CmaCasePresenter do
       specify do
         subject.date_metadata.should eq({})
       end
+    end
+  end
+
+  describe "details" do
+    it "returns the headers if there are some" do
+      headers_array = ['blah']
+      details_attributes.merge!(headers: ['blah'])
+      expect(presenter.headers).to eq(headers_array)
+    end
+
+    it "returns an empty array if there is no headers in the details hash" do
+      allow(document_details).to receive(:headers) { nil }
+      expect(presenter.headers).to eq([])
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where headers were not displayed. Instead of returning the details hash return the actual headers. Adds a test case to prove it works too!
