### PR TITLE
Add remaining AAIB report metadata fields

### DIFF
--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -1,12 +1,19 @@
 class AaibReportPresenter < DocumentPresenter
-
-  delegate :date_of_occurrence,
-    :aircraft_category,
+  delegate :aircraft_category,
+    :aircraft_types,
+    :date_of_occurrence,
+    :location,
+    :registrations,
     :report_type,
     to: :"document.details"
 
   def format_name
     "Air Accidents Investigation Branch report"
+  end
+
+  def metadata
+    super
+      .merge(non_schemaified_metadata)
   end
 
 private
@@ -20,6 +27,14 @@ private
     {
       aircraft_category: aircraft_category,
       report_type: report_type,
+    }
+  end
+
+  def non_schemaified_metadata
+    {
+      "Aircraft types" => [aircraft_types],
+      "Location" => [location],
+      "Registrations" => registrations,
     }
   end
 end

--- a/spec/presenters/aaib_report_presenter_spec.rb
+++ b/spec/presenters/aaib_report_presenter_spec.rb
@@ -15,23 +15,48 @@ describe AaibReportPresenter do
 
   let(:updated_at) { DateTime.new(2014, 4, 1) }
 
-  let(:detail_object) { double(:detail_object, document_details) }
+  let(:detail_object) { double(:detail_object, detail_attributes) }
 
-  let(:document_details) {
+  let(:schema_attributes) {
     {
       aircraft_category: "Big Aeroplanes",
       report_type: "a report type",
     }
   }
 
-  let(:schema) { double(:schema) }
+  let(:detail_attributes) {
+    schema_attributes.merge({
+      aircraft_types: "some types of aircraft",
+      location: "a location",
+      registrations: "some registrations",
+    })
+  }
+
+  let(:user_friendly_document_details) {
+    {
+      "Aircraft category" => "Big Aeroplanes",
+      "Report type" => "a report type",
+    }
+  }
+
+  let(:schema) {
+    double(:schema, user_friendly_values: user_friendly_document_details)
+  }
 
   describe "#metadata" do
     it "converts raw metadata to user friendly metadata via the schema" do
       expect(schema).to receive(:user_friendly_values)
-        .with(document_details)
+        .with(schema_attributes)
 
       presenter.metadata
+    end
+
+    it "contains the extra fields that are not in the schema" do
+      expect(presenter.metadata).to include(
+        "Aircraft types",
+        "Location",
+        "Registrations",
+      )
     end
   end
 


### PR DESCRIPTION
Aircraft types, Location, Registrations are free text fields not in the AAIB schema so have to be merged into the metadata hash.

with @kalleth 
