### PR TITLE
Add extra fields to AAIB Reports

### DIFF
--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -3,6 +3,9 @@ class AaibReportPresenter < DocumentPresenter
   delegate :date_of_occurrence,
     :aircraft_category,
     :report_type,
+    :aircraft_type,
+    :registration,
+    :location,
     to: :"document.details"
 
   def format_name
@@ -21,6 +24,9 @@ private
     {
       aircraft_category: aircraft_category,
       report_type: report_type,
+      aircraft_type: aircraft_type,
+      registration: registration,
+      location: location,
     }
   end
 end

--- a/spec/presenters/aaib_report_presenter_spec.rb
+++ b/spec/presenters/aaib_report_presenter_spec.rb
@@ -21,6 +21,9 @@ describe AaibReportPresenter do
     {
       aircraft_category: "Big Aeroplanes",
       report_type: "a report type",
+      aircraft_type: "a UFO",
+      registration: "ET1",
+      location: "Bermuda Triangle",
     }
   }
 


### PR DESCRIPTION
This adds aircraft_type, registration and location to AAIB Reports. Requires https://github.com/alphagov/specialist-publisher/pull/185 to be merged too. [Ticket](https://trello.com/c/aqPo7Nww/236-add-extra-fields-into-aaib-specialist-publisher).
