### PR TITLE
Allow International Development Funds to be viewed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'cucumber-rails', '1.4.0', require: false
   gem 'webmock', '1.17.1'
   gem 'rspec-rails', '2.14.1'
+  gem 'launchy'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       sprockets-rails
     json (1.8.1)
     kgio (2.8.1)
+    launchy (2.4.2)
+      addressable (~> 2.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)
@@ -210,6 +212,7 @@ DEPENDENCIES
   gds-api-adapters (= 12.0.0)
   govuk_frontend_toolkit (= 0.45.0)
   jasmine-rails
+  launchy
   logstasher (= 0.4.8)
   plek (= 1.3.0)
   pry

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -29,6 +29,8 @@ private
       # TODO: Remove 'specialist-document' once docs
       # have been republished and panopticon has correct 'format'.
       CmaCasePresenter.new(schema("cma-cases"), artefact)
+    when "international_development_fund"
+      InternationalDevelopmentFundPresenter.new(schema("international-development-funds"), artefact)
     when "aaib_report"
       AaibReportPresenter.new(schema("aaib-reports"), artefact)
     else

--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -10,7 +10,6 @@ class AaibReportPresenter < DocumentPresenter
   end
 
 private
-
   def extra_date_metadata
     {
       "Date of occurrence" => date_of_occurrence,

--- a/app/presenters/international_development_fund_presenter.rb
+++ b/app/presenters/international_development_fund_presenter.rb
@@ -1,0 +1,25 @@
+class InternationalDevelopmentFundPresenter < DocumentPresenter
+  delegate(
+    :application_state,
+    :location,
+    :document_sector,
+    :eligible_entities,
+    :value_of_fund,
+    to: :"document.details"
+  )
+
+  def format_name
+    "International development funding"
+  end
+
+private
+  def extra_raw_metadata
+    {
+      application_state: application_state,
+      location: location,
+      document_sector: document_sector,
+      eligible_entities: eligible_entities,
+      value_of_fund: value_of_fund,
+    }
+  end
+end

--- a/features/fixtures/schemas/international-development-funding-schema.json
+++ b/features/fixtures/schemas/international-development-funding-schema.json
@@ -1,0 +1,247 @@
+{
+  "slug": "international-development-funding",
+  "name": "International development funding",
+  "document_noun": "fund",
+  "facets": [
+    {
+      "key": "application_state",
+      "name": "Applications",
+      "type": "single-select",
+      "include_blank": false,
+      "preposition": "which are",
+      "allowed_values": [
+        {"label": "Open", "value": "open"},
+        {"label": "Closed", "value": "closed"},
+        {"label": "All", "value": "", "non_described": true }
+      ]
+    },
+    {
+      "key": "location",
+      "name": "Countries and regions",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "for",
+      "allowed_values": [
+        {
+          "label": "Afghanistan",
+          "value": "afghanistan"
+        },
+        {
+          "label": "Bangladesh",
+          "value": "bangladesh"
+        },
+        {
+          "label": "Burma",
+          "value": "burma"
+        },
+        {
+          "label": "Democratic Republic of Congo",
+          "value": "democratic-republic-of-congo"
+        },
+        {
+          "label": "Ethiopia",
+          "value": "ethiopia"
+        },
+        {
+          "label": "Ghana",
+          "value": "ghana"
+        },
+        {
+          "label": "India",
+          "value": "india"
+        },
+        {
+          "label": "Kenya",
+          "value": "kenya"
+        },
+        {
+          "label": "Kyrgyzstan",
+          "value": "kyrgyzstan"
+        },
+        {
+          "label": "Liberia",
+          "value": "liberia"
+        },
+        {
+          "label": "Malawi",
+          "value": "malawi"
+        },
+        {
+          "label": "Mozambique",
+          "value": "mozambique"
+        },
+        {
+          "label": "Nepal",
+          "value": "nepal"
+        },
+        {
+          "label": "Nigeria",
+          "value": "nigeria"
+        },
+        {
+          "label": "The Occupied Palestinian Territories",
+          "value": "the-occupied-palestinian-territories"
+        },
+        {
+          "label": "Pakistan",
+          "value": "pakistan"
+        },
+        {
+          "label": "Rwanda",
+          "value": "rwanda"
+        },
+        {
+          "label": "Sierra Leone",
+          "value": "sierra-leone"
+        },
+        {
+          "label": "Somalia",
+          "value": "somalia"
+        },
+        {
+          "label": "South Africa",
+          "value": "south-africa"
+        },
+        {
+          "label": "Sudan",
+          "value": "sudan"
+        },
+        {
+          "label": "South Sudan",
+          "value": "south-sudan"
+        },
+        {
+          "label": "Tajikistan",
+          "value": "tajikistan"
+        },
+        {
+          "label": "Tanzania",
+          "value": "tanzania"
+        },
+        {
+          "label": "Uganda",
+          "value": "uganda"
+        },
+        {
+          "label": "Yemen",
+          "value": "yemen"
+        },
+        {
+          "label": "Zambia",
+          "value": "zambia"
+        },
+        {
+          "label": "Zimbabwe",
+          "value": "zimbabwe"
+        }
+      ]
+    },
+    {
+      "key": "document_sector",
+      "name": "Sector",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "for",
+      "allowed_values": [
+        {
+          "label": "Education",
+          "value": "education"
+        },
+        {
+          "label": "Health",
+          "value": "health"
+        },
+        {
+          "label": "Humanitarian emergencies/disasters",
+          "value": "humanitarian-emergencies-disasters"
+        },
+        {
+          "label": "Disabilities",
+          "value": "disabilities"
+        },
+        {
+          "label": "Climate change",
+          "value": "climate-change"
+        },
+        {
+          "label": "Girls and women",
+          "value": "girls-and-women"
+        },
+        {
+          "label": "Water and sanitation",
+          "value": "water-and-sanitation"
+        },
+        {
+          "label": "Empowerment and accountability",
+          "value": "empowerment-and-accountability"
+        },
+        {
+          "label": "Private sector/commercial",
+          "value": "private-sector-commercial"
+        },
+        {
+          "label": "Livelihoods",
+          "value": "livelihoods"
+        },
+        {
+          "label": "Peace and access to justice",
+          "value": "peace-and-access-to-justice"
+        }
+      ]
+    },
+    {
+      "key": "eligible_entities",
+      "name": "Eligible organisations",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "open to",
+      "allowed_values": [
+        {
+          "label": "Non-governmental organisations (NGOs)",
+          "value": "non-governmental-organisations"
+        },
+        {
+          "label": "UK-based non-profit organisations",
+          "value": "uk-based-non-profit-organisations"
+        },
+        {
+          "label": "UK-based small and diaspora organisations",
+          "value": "uk-based-small-and-diaspora-organisations"
+        },
+        {
+          "label": "Companies",
+          "value": "companies"
+        },
+        {
+          "label": "Local government",
+          "value": "local-government"
+        },
+        {
+          "label": "Educational institutions",
+          "value": "educational-institutions"
+        },
+        {
+          "label": "Individuals",
+          "value": "individuals"
+        },
+        {
+          "label": "Humanitarian relief organisations",
+          "value": "humanitarian-relief-organisations"
+        }
+      ]
+    },
+    {
+      "key": "value_of_fund",
+      "name": "Value of fund",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "with value",
+      "allowed_values": [
+        {"label": "Up to £100,000", "value": "up-to-100000"},
+        {"label": "£100,001 to £500,000", "value": "100001-500000"},
+        {"label": "£500,001 to £1,000,000", "value": "500001-to-1000000"},
+        {"label": "More than £1,000,000", "value": "more-than-1000000"}
+      ]
+    }
+  ]
+}

--- a/features/international-development-fund-viewing.feature
+++ b/features/international-development-fund-viewing.feature
@@ -1,0 +1,9 @@
+Feature: International development fund viewing
+  As a specialist member of the public
+  I want to be able to view international development funds
+  So that I can learn where government funding goes
+
+Scenario: Viewing a published fund
+  Given a published international development fund exists
+  When I visit the document page
+  Then I should see the fund's content

--- a/features/published-case-viewing.feature
+++ b/features/published-case-viewing.feature
@@ -5,5 +5,5 @@ Feature: Published case viewing
 
 Scenario: Viewing a published case
   Given a published case
-  When I visit the case page
+  When I visit the document page
   Then I should see the case's content

--- a/features/step_definitions/case_steps.rb
+++ b/features/step_definitions/case_steps.rb
@@ -30,17 +30,17 @@ Given(/^a published case$/) do
   finder_api_has_schema("cma-cases")
 end
 
-When(/^I visit the case page$/) do
+When(/^I visit the document page$/) do
   visit "/#{@slug}"
 end
 
 Then(/^I should see the case's content$/) do
   expect(page).to have_content(@title)
   expect(page).to have_content(@summary)
-  expect(page).to have_content(@artefact[:opened_date])
-  expect(page).to have_content(@artefact[:closed_date])
-  expect(page).to have_content(@artefact[:case_type])
-  expect(page).to have_content(@artefact[:case_state])
+  expect(page).to have_content("1 January 2012")
+  expect(page).to have_content("21 November 2014")
+  expect(page).to have_content("Regulatory references and appeals")
+  expect(page).to have_content("Closed")
 end
 
 def slug_from_title(title)

--- a/features/step_definitions/international_development_fund_steps.rb
+++ b/features/step_definitions/international_development_fund_steps.rb
@@ -1,0 +1,38 @@
+Given(/^a published international development fund exists$/) do
+  @title = "Protracted Relief Programme Phase 1"
+  @slug = slug_from_title(@title)
+  @summary = "Stabilising food security for 1.5 million people in Zimbabwe"
+
+  @artefact = artefact_for_slug(@slug).merge(
+    "title" => @title,
+    "format" => "international_development_fund",
+    "details" => {
+      "body" => "<p>Body content</p>\n",
+      "summary" => @summary,
+      "application_state" => "open",
+      "location" => ["mozambique", "zambia", "zimbabwe"],
+      "document_sector" => ["health", "disabilities"],
+      "eligible_entities" => ["companies", "local-government"],
+      "value_of_fund" => "100001-500000",
+    }
+  )
+
+  content_api_has_an_artefact(@slug, @artefact)
+  finder_api_has_schema("international-development-funds", idf_schema)
+end
+
+Then(/^I should see the fund's content$/) do
+  expect(page).to have_content(@title)
+  expect(page).to have_content(@summary)
+  expect(page).to have_content("Open")
+  expect(page).to have_content("Mozambique, Zambia and Zimbabwe")
+  expect(page).to have_content("Health and Disabilities")
+  expect(page).to have_content("Companies and Local government")
+  expect(page).to have_content("£100,001 to £500,000")
+end
+
+def idf_schema
+  File.read(
+    File.expand_path('../../fixtures/schemas/international-development-funding-schema.json', __FILE__)
+  )
+end


### PR DESCRIPTION
([Trello ticket](https://trello.com/c/QUI3M1Kx/226-dfid-finder-add-support-to-specialist-frontend-for-rendering-international-development-funds-2]))
- Add InternationalDevelopmentFund presenter
- Add cucumber spec mirroring CMA cases.
- Fix CMA case cucumber spec (was looking for nil)

Development/Test only:
- Add launchy gem to allow save_and_open_page in test suite in future.
