### PR TITLE
Change how we refer to the international-development-funding schema

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -30,7 +30,7 @@ private
       # have been republished and panopticon has correct 'format'.
       CmaCasePresenter.new(schema("cma-cases"), artefact)
     when "international_development_fund"
-      InternationalDevelopmentFundPresenter.new(schema("international-development-funds"), artefact)
+      InternationalDevelopmentFundPresenter.new(schema("international-development-funding"), artefact)
     when "aaib_report"
       AaibReportPresenter.new(schema("aaib-reports"), artefact)
     else

--- a/features/step_definitions/international_development_fund_steps.rb
+++ b/features/step_definitions/international_development_fund_steps.rb
@@ -18,7 +18,7 @@ Given(/^a published international development fund exists$/) do
   )
 
   content_api_has_an_artefact(@slug, @artefact)
-  finder_api_has_schema("international-development-funds", idf_schema)
+  finder_api_has_schema("international-development-funding", idf_schema)
 end
 
 Then(/^I should see the fund's content$/) do


### PR DESCRIPTION
Now that I can actually try and view international development funds in the frontend I realised that this was using the wrong identifier for the schema (500 error! Now not 500 error. :))

funds -> funding
