### PR TITLE
Add CSS for non <fig> wrapped images

### DIFF
--- a/app/assets/stylesheets/_govspeak.scss
+++ b/app/assets/stylesheets/_govspeak.scss
@@ -169,6 +169,12 @@
     }
   }
 
+  img {
+    width: auto;
+    height: auto;
+    max-width: $full-width;
+  }
+
   sup {
     font-size: 0.8em;
     line-height: 0.7em;


### PR DESCRIPTION
As we need images for the DFID Finder, uploading attachments and prepending a bang to the attachment code parses it as an image, althought it's outside of a <fig> tag. This CSS means that it stays within it's container and can resize. [Ticket](https://trello.com/c/pSWg7ySv/228-add-styling-for-images-1).

![screen shot 2014-07-28 at 15 36 11](https://cloud.githubusercontent.com/assets/449004/3721840/90c2d4b8-1664-11e4-83c9-10f68d3fbb41.png)
