### PR TITLE
Use published_at as the "Updated at" to display.

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,8 +1,9 @@
 class DocumentPresenter
 
-  delegate :title, :details, :updated_at, to: :document
+  delegate :title, :details, to: :document
   delegate :summary,
     :body,
+    :published_at,
     to: :"document.details"
 
   def initialize(schema, document)
@@ -73,7 +74,7 @@ private
 
   def default_date_metadata
     {
-      "Updated at" => updated_at,
+      "Updated at" => published_at,
     }
   end
 

--- a/spec/presenters/aaib_report_presenter_spec.rb
+++ b/spec/presenters/aaib_report_presenter_spec.rb
@@ -8,12 +8,11 @@ describe AaibReportPresenter do
     double(
       :document,
       title: "A Document",
-      updated_at: updated_at,
       details: detail_object,
     )
   end
 
-  let(:updated_at) { DateTime.new(2014, 4, 1) }
+  let(:published_at) { DateTime.new(2014, 4, 1) }
 
   let(:detail_object) { double(:detail_object, document_details) }
 
@@ -63,12 +62,13 @@ describe AaibReportPresenter do
     let(:detail_object) do
       OpenStruct.new(
         date_of_occurrence: Date.new(2013, 9, 1),
+        published_at: published_at,
       )
     end
 
     specify do
       subject.date_metadata.should eq({
-        "Updated at" => updated_at,
+        "Updated at" => published_at,
         "Date of occurrence" => Date.new(2013, 9, 1),
       })
     end

--- a/spec/presenters/cma_case_presenter_spec.rb
+++ b/spec/presenters/cma_case_presenter_spec.rb
@@ -8,12 +8,11 @@ describe CmaCasePresenter do
     double(
       :document,
       title: "A Document",
-      updated_at: updated_at,
       details: detail_object,
     )
   end
 
-  let(:updated_at) { DateTime.new(2014, 4, 1) }
+  let(:published_at) { DateTime.new(2014, 4, 1) }
 
   let(:detail_object) { double(:detail_object, document_details) }
 
@@ -54,12 +53,13 @@ describe CmaCasePresenter do
       OpenStruct.new(
         opened_date: Date.new(2013, 9, 1),
         closed_date: Date.new(2014, 3, 1),
+        published_at: published_at,
       )
     end
 
     specify do
       subject.date_metadata.should eq({
-        "Updated at" => updated_at,
+        "Updated at" => published_at,
         "Opened date" => Date.new(2013, 9, 1),
         "Closed date" => Date.new(2014, 3, 1),
       })

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -32,17 +32,20 @@ describe DocumentPresenter do
     double(
       :document,
       title: document_title,
-      updated_at: document_updated_at,
       details: document_details,
     )
   end
 
   let(:document_title) { "A Document" }
-  let(:document_updated_at) { 3.days.ago }
+  let(:document_published_at) { 3.days.ago }
   let(:document_details) { double(:document_details, all_attributes) }
   let(:filterable_attributes) { { foo: foo } }
   let(:extra_attributes) { { bar: bar } }
-  let(:all_attributes) { filterable_attributes.merge(extra_attributes) }
+  let(:all_attributes) {
+    filterable_attributes.merge(extra_attributes).merge({
+      published_at: document_published_at,
+    })
+  }
 
   let(:schema_response) {
     {
@@ -102,7 +105,7 @@ describe DocumentPresenter do
 
   describe "#date_metadata" do
     context "with all attributes present" do
-      let(:document_updated_at) { DateTime.new(2014, 4, 1) }
+      let(:document_published_at) { DateTime.new(2014, 4, 1) }
 
       specify do
         subject.date_metadata.should eq({
@@ -112,7 +115,7 @@ describe DocumentPresenter do
     end
 
     context "with closed date blank" do
-      let(:document_updated_at) { nil }
+      let(:document_published_at) { nil }
 
       specify do
         subject.date_metadata.should eq({})


### PR DESCRIPTION
This means we control when the document is shown as having been updated,
not mongoid.

Depends on the content API reporting this information.
- [x] Merge content API pull request https://github.com/alphagov/govuk_content_api/pull/200
