### PR TITLE
All AAIB metadata is singular

### DIFF
--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -2,9 +2,9 @@ class AaibReportPresenter < DocumentPresenter
 
   delegate :date_of_occurrence,
     :aircraft_category,
-    :aircraft_types,
+    :aircraft_type,
     :location,
-    :registrations,
+    :registration,
     :report_type,
     to: :"document.details"
 
@@ -32,9 +32,9 @@ private
 
   def extra_metadata
     {
-      "Aircraft types" => aircraft_types,
+      "Aircraft types" => aircraft_type,
       "Location" => location,
-      "Registrations" => registrations,
+      "Registrations" => registration,
     }
   end
 end

--- a/spec/presenters/aaib_report_presenter_spec.rb
+++ b/spec/presenters/aaib_report_presenter_spec.rb
@@ -30,8 +30,8 @@ describe AaibReportPresenter do
 
   let(:extra_metadata) {
     {
-      aircraft_types: "Jumbo Jets and Kitchenettes",
-      registrations: ["G-BAOZ", "G-BIVE"],
+      aircraft_type: "Jumbo Jets and Kitchenettes",
+      registration: ["G-BAOZ", "G-BIVE"],
       location: "Just outside Slough",
     }
   }


### PR DESCRIPTION
aircraft_types and registrations are actually singular everywhere except here. Hence they weren't displaying as they were nil.
