### PR TITLE
Fix links to docs from pre filtered Finder

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -50,7 +50,7 @@ private
         OpenStruct.new(
           label: value.fetch(:label),
           linkable?: true,
-          href: "#{finder_path}/?#{key}%5B%5D=#{value.fetch(:slug)}"
+          href: "#{finder_path}?#{key}%5B%5D=#{value.fetch(:slug)}"
         )
       }
     )

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -79,7 +79,7 @@ describe DocumentPresenter do
         linkable_value = linkable.values.first
 
         expect(linkable_value.linkable?).to eq(true)
-        expect(linkable_value.href).to eq("/finder/?foo%5B%5D=bar")
+        expect(linkable_value.href).to eq("/finder?foo%5B%5D=bar")
 
         unlinkable = metadata.select { |m| m.label == "Bar" }.first
         unlinkable_value = unlinkable.values.first


### PR DESCRIPTION
When linking back to a pre-filtered Finder, the URL has a trailing slash which then breaks links to documents as they are set as `finder-path/doc-name` which it assumes are then at `finder-path/finder-path/doc-name`. This commit removes the trailing slash.
