### PR TITLE
Make dt metadata tag wider

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,7 @@
         float: left;
         clear: left;
         width: auto;
-        min-width: 120px;
+        min-width: 140px;
         @include media(tablet){
           padding-right: $gutter-one-third;
         }


### PR DESCRIPTION
With the introduction of the DFID finder we have some longer `<dt>` tag that go make the `<dd>` tags not in line. This commit makes the `<dt>` a bit wider to account for this. Screenshots:

Before: 
![screen shot 2014-08-01 at 11 32 55](https://cloud.githubusercontent.com/assets/449004/3777803/9969ceb8-1967-11e4-9f27-2eaef41772b1.png)

After:
![screen shot 2014-08-01 at 11 35 56](https://cloud.githubusercontent.com/assets/449004/3777805/a5b7d5f2-1967-11e4-8454-a38d90ab8b93.png)
