### PR TITLE
Add Medical Safety Alerts

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -33,6 +33,8 @@ private
       DrugSafetyUpdatePresenter.new(schema("drug-safety-update"), artefact)
     when "international_development_fund"
       InternationalDevelopmentFundPresenter.new(schema("international-development-funding"), artefact)
+    when "medical_safety_alert"
+      MedicalSafetyAlertPresenter.new(schema("medical-safety-alert"), artefact)
     else
       DocumentPresenter.new(NullSchema.new, artefact)
     end

--- a/app/presenters/medical_safety_alert_presenter.rb
+++ b/app/presenters/medical_safety_alert_presenter.rb
@@ -1,0 +1,23 @@
+class MedicalSafetyAlertPresenter < DocumentPresenter
+  delegate(
+    :alert_type,
+    :medical_specialism,
+    to: :"document.details"
+  )
+
+  def format_name
+    "Medical safety alert"
+  end
+
+  def finder_path
+    "/drug-device-alerts"
+  end
+
+private
+  def filterable_metadata
+    {
+      alert_type: alert_type,
+      medical_specialism: medical_specialism,
+    }
+  end
+end

--- a/features/fixtures/schemas/medical-safety-alert-schema.json
+++ b/features/fixtures/schemas/medical-safety-alert-schema.json
@@ -1,0 +1,49 @@
+{
+  "slug": "drug-device-alerts",
+  "name": "Alerts and recalls for drugs and medical devices",
+  "document_noun": "alert",
+  "facets": [
+    {
+      "key": "alert_type",
+      "name": "Alert type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Drugs", "value": "drugs"},
+        {"label": "Devices", "value": "devices"}
+      ]
+    },
+    {
+      "key": "medical_specialism",
+      "name": "Medical specialism",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "in medical specialism",
+      "allowed_values": [
+        {"label": "Anaesthetics", "value": "anaesthetics" },
+        {"label": "Cardiology", "value": "cardiology" },
+        {"label": "Care home staff", "value": "care-home-staff" },
+        {"label": "Cosmetic surgery", "value": "cosmetic-surgery" },
+        {"label": "Critical care", "value": "critical-care" },
+        {"label": "Dentistry", "value": "dentistry" },
+        {"label": "General practice", "value": "general-practice" },
+        {"label": "General surgery", "value": "general-surgery" },
+        {"label": "Haematology and oncology", "value": "haematology-and-oncology" },
+        {"label": "Infection prevention", "value": "infection-prevention" },
+        {"label": "Obstetrics and gynaecology", "value": "obstetrics-and-gynaecology" },
+        {"label": "Ophthalmology", "value": "ophthalmology" },
+        {"label": "Orthopaedics", "value": "orthopaedics" },
+        {"label": "Paediatrics", "value": "paediatrics" },
+        {"label": "Pathology", "value": "pathology" },
+        {"label": "Pharmacy", "value": "pharmacy" },
+        {"label": "Physiotherapy and occupational therapy", "value": "physiotherapy-and-occupational-therapy" },
+        {"label": "Radiology", "value": "radiology" },
+        {"label": "Renal medicine", "value": "renal-medicine" },
+        {"label": "Theatre practitioners", "value": "theatre-practitioners" },
+        {"label": "Urology", "value": "urology" },
+        {"label": "Vascular and cardiac surgery", "value": "vascular-and-cardiac-surgery" }
+      ]
+    }
+  ]
+}

--- a/features/medical-safety-alert-viewing.feature
+++ b/features/medical-safety-alert-viewing.feature
@@ -1,0 +1,9 @@
+Feature: Medical safety alert viewing
+  As a specialist member of the public
+  I want to be able to view drug and device alerts
+  So that I can find out about drug and device alerts
+
+Scenario: Viewing a published alert
+  Given a published medical safety alert exists
+  When I visit the document page
+  Then I see the content of the medical safety alert

--- a/features/step_definitions/medical_safety_alert_steps.rb
+++ b/features/step_definitions/medical_safety_alert_steps.rb
@@ -1,0 +1,31 @@
+Given(/^a published medical safety alert exists$/) do
+  @title = "Alert about Panacea"
+  @slug = slug_from_title(@title)
+  @summary = "Alert about Panacea"
+
+  @artefact = artefact_for_slug(@slug).merge(
+    "title" => @title,
+    "format" => "medical_safety_alert",
+    "details" => {
+      "body" => "<p>Body content</p>\n",
+      "summary" => @summary,
+      "alert_type" => ["drugs"],
+      "medical_specialism" => ["general-practice"],
+    }
+  )
+
+  content_api_has_an_artefact(@slug, @artefact)
+  finder_api_has_schema("medical-safety-alert", medical_safety_alert_schema)
+end
+
+Then(/^I see the content of the medical safety alert$/) do
+  expect(page).to have_content(@title)
+  expect(page).to have_content(@summary)
+  expect(page).to have_content("General practice")
+end
+
+def medical_safety_alert_schema
+  File.read(
+    File.expand_path('../../fixtures/schemas/medical-safety-alert-schema.json', __FILE__)
+  )
+end


### PR DESCRIPTION
Add presenter for MSAs and testing viewing an Alert. [Ticket](https://trello.com/c/LN4aLOOW/283-alerts-finder-add-support-to-finder-frontend-for-registering-and-rendering-the-alerts-and-recalls-for-drugs-and-medical-devices-).
