### PR TITLE
Add issued date to medical safety alerts

### DIFF
--- a/app/presenters/medical_safety_alert_presenter.rb
+++ b/app/presenters/medical_safety_alert_presenter.rb
@@ -2,6 +2,7 @@ class MedicalSafetyAlertPresenter < DocumentPresenter
   delegate(
     :alert_type,
     :medical_specialism,
+    :issued_date,
     to: :"document.details"
   )
 
@@ -18,6 +19,12 @@ private
     {
       alert_type: alert_type,
       medical_specialism: medical_specialism,
+    }
+  end
+
+  def extra_date_metadata
+    {
+      "Issued date" => issued_date,
     }
   end
 end


### PR DESCRIPTION
Add the issued date attribute to the medical safety alaert date metadata in  the presenter so that it can be shown in the frontend. This corresponds to this commit in specialist publisher:
https://github.com/alphagov/specialist-publisher/pull/281

The trello ticket can be found here:
https://trello.com/c/QFE3nYlc/361-add-issued-date-to-medical-safety-alerts-2
