### PR TITLE
Add published_at date to visible metadata for DSU documents

### DIFF
--- a/app/presenters/drug_safety_update_presenter.rb
+++ b/app/presenters/drug_safety_update_presenter.rb
@@ -1,7 +1,7 @@
 class DrugSafetyUpdatePresenter < DocumentPresenter
   delegate(
     :therapeutic_area,
-    :published_date,
+    :first_published_at,
     to: :"document.details"
   )
 
@@ -22,7 +22,7 @@ private
 
   def extra_date_metadata
     {
-      "Published date" => published_date,
+      "Published at" => first_published_at,
     }
   end
 end


### PR DESCRIPTION
This adds published_at date and makes it available for viewing on specialist-frontend.

Trello ticket: https://trello.com/c/ZW0i6nya/362-add-first-published-date-to-the-dsu-finder-3-1
