### PR TITLE
Add MAIB report format

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -33,6 +33,8 @@ private
       DrugSafetyUpdatePresenter.new(schema("drug-safety-update"), artefact)
     when "international_development_fund"
       InternationalDevelopmentFundPresenter.new(schema("international-development-funding"), artefact)
+    when "maib_report"
+      MaibReportPresenter.new(schema("maib-reports"), artefact)
     when "medical_safety_alert"
       MedicalSafetyAlertPresenter.new(schema("drug-device-alerts"), artefact)
     else

--- a/app/presenters/maib_report_presenter.rb
+++ b/app/presenters/maib_report_presenter.rb
@@ -1,0 +1,29 @@
+class MaibReportPresenter < DocumentPresenter
+
+  delegate :date_of_occurrence,
+    :vessel_type,
+    :report_type,
+    to: :"document.details"
+
+  def format_name
+    "Marine Accident Investigation Branch report"
+  end
+
+  def finder_path
+    "/maib-reports"
+  end
+
+private
+  def extra_date_metadata
+    {
+      "Date of occurrence" => date_of_occurrence,
+    }
+  end
+
+  def filterable_metadata
+    {
+      vessel_type: vessel_type,
+      report_type: report_type,
+    }
+  end
+end

--- a/features/fixtures/schemas/maib-reports.json
+++ b/features/fixtures/schemas/maib-reports.json
@@ -1,0 +1,39 @@
+{
+  "slug": "maib-reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "vessel_type",
+      "name": "Vessel type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Merchant vessel 100 gross tons or over", "value": "merchant-vessel-100-gross-tons-or-over"},
+        {"label": "Merchant vessel under 100 gross tons", "value": "merchant-vessel-under-100-gross-tons"},
+        {"label": "Fishing vessel", "value": "fishing-vessel"},
+        {"label": "Recreational craft - sail", "value": "recreational-craft-sail"},
+        {"label": "Recreational craft - power", "value": "recreational-craft-power"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Investigation reports", "value": "investigation-reports"},
+        {"label": "Safety bulletins", "value": "safety-bulletins"},
+        {"label": "Completed preliminary examinations", "value": "completed-preliminary-examinations"},
+        {"label": "Overseas reports", "value": "overseas-reports"}
+      ]
+    },
+    {
+      "key": "date_of_occurrence",
+      "name": "Date of occurrence",
+      "type": "date",
+      "preposition": "occurred"
+    }
+  ]
+}

--- a/features/maib-report-viewing.feature
+++ b/features/maib-report-viewing.feature
@@ -1,0 +1,9 @@
+Feature: MAIB report viewing
+  As a specialist member of the public
+  I want to be able to view MAIB reports
+  So that I can find out about air accidents
+
+Scenario: Viewing a published update
+  Given a published MAIB report exists
+  When I visit the document page
+  Then I see the content of the MAIB report

--- a/features/step_definitions/maib_report_steps.rb
+++ b/features/step_definitions/maib_report_steps.rb
@@ -1,0 +1,45 @@
+Given(/^a published MAIB report exists$/) do
+  @title = "This is a test MAIB Report"
+  @slug = slug_from_title(@title)
+
+  @artefact = artefact_for_slug(@slug).merge(
+    "title" => @title,
+    "format" => "maib_report",
+    "details" => {
+      "body" => "<p>Body content</p>\n",
+      "summary" => 'Summary of MAIB report',
+      "date_of_occurrence" => "2014-01-01",
+      "summary" => nil,
+      "vessel_type" => "fishing-vessel",
+      "vessel_type_label" => "Fishing vessel",
+      "report_type" => "investigation-reports",
+      "report_type_label" => "Investigation reports",
+      "updated_at" => "2014-10-24T08:41:18Z",
+      "date_of_occurrence" => "1992-04-03",
+      "published_at" => "2014-10-24T08:41:18Z",
+    }
+  )
+
+  content_api_has_an_artefact(@slug, @artefact)
+  finder_api_has_schema("maib-reports", maib_report_schema)
+end
+
+Then(/^I see the content of the MAIB report$/) do
+  expect(page).to have_content(@title)
+  check_metadata_value("Updated at", "24 October 2014")
+  check_metadata_value("Date of occurrence", "3 April 1992")
+  check_metadata_value("Vessel type", "Fishing vessel")
+  check_metadata_value("Report type", "Investigation report")
+end
+
+def check_metadata_value(key, value)
+  within(".metadata") do
+    expect(page).to have_content("#{key}: #{value}")
+  end
+end
+
+def maib_report_schema
+  File.read(
+    File.expand_path('../../fixtures/schemas/maib-reports.json', __FILE__)
+  )
+end


### PR DESCRIPTION
This commit adds a presenter for the MAIB Report and calls that correctly from the specialist documents controller.

It also adds a feature for testing viewing of MAIB Reports. [Ticket](https://trello.com/c/t240dCwY/370-maib-finder-add-support-to-finder-frontend-for-registering-and-rendering-maib-reports-2).
