### PR TITLE
Add RAIB report format

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -35,6 +35,8 @@ private
       InternationalDevelopmentFundPresenter.new(schema("international-development-funding"), artefact)
     when "medical_safety_alert"
       MedicalSafetyAlertPresenter.new(schema("drug-device-alerts"), artefact)
+    when "raib_report"
+      RaibReportPresenter.new(schema("raib-reports"), artefact)
     else
       DocumentPresenter.new(NullSchema.new, artefact)
     end

--- a/app/presenters/raib_report_presenter.rb
+++ b/app/presenters/raib_report_presenter.rb
@@ -1,0 +1,29 @@
+class RaibReportPresenter < DocumentPresenter
+
+  delegate :date_of_occurrence,
+    :railway_type,
+    :report_type,
+    to: :"document.details"
+
+  def format_name
+    "Rail Accident Investigation Branch report"
+  end
+
+  def finder_path
+    "/raib-reports"
+  end
+
+private
+  def extra_date_metadata
+    {
+      "Date of occurrence" => date_of_occurrence,
+    }
+  end
+
+  def filterable_metadata
+    {
+      railway_type: railway_type,
+      report_type: report_type,
+    }
+  end
+end

--- a/features/fixtures/schemas/raib-reports.json
+++ b/features/fixtures/schemas/raib-reports.json
@@ -1,0 +1,38 @@
+{
+  "slug": "raib-reports",
+  "document_noun": "report",
+  "facets": [
+    {
+      "key": "railway_type",
+      "name": "Railway type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Heavy rail", "value": "heavy-rail"},
+        {"label": "Light rail", "value": "light-rail"},
+        {"label": "Metros", "value": "metros"},
+        {"label": "Heritage railways", "value": "heritage-railways"}
+      ]
+    },
+    {
+      "key": "report_type",
+      "name": "Report type",
+      "type": "multi-select",
+      "include_blank": false,
+      "preposition": "of type",
+      "allowed_values": [
+        {"label": "Investigation reports", "value": "investigation-reports"},
+        {"label": "Bulletins", "value": "bulletins"},
+        {"label": "Interim reports", "value": "interim-reports"},
+        {"label": "Discontinuation reports", "value": "discontinuation-reports"}
+      ]
+    },
+    {
+      "key": "date_of_occurrence",
+      "name": "Date of occurrence",
+      "type": "date",
+      "preposition": "occurred"
+    }
+  ]
+}

--- a/features/raib-report-viewing.feature
+++ b/features/raib-report-viewing.feature
@@ -1,0 +1,9 @@
+Feature: RAIB report viewing
+  As a specialist member of the public
+  I want to be able to view RAIB reports
+  So that I can find out about air accidents
+
+Scenario: Viewing a published update
+  Given a published RAIB report exists
+  When I visit the document page
+  Then I see the content of the RAIB report

--- a/features/step_definitions/raib_report_steps.rb
+++ b/features/step_definitions/raib_report_steps.rb
@@ -1,0 +1,45 @@
+Given(/^a published RAIB report exists$/) do
+  @title = "This is a test RAIB Report"
+  @slug = slug_from_title(@title)
+
+  @artefact = artefact_for_slug(@slug).merge(
+    "title" => @title,
+    "format" => "raib_report",
+    "details" => {
+      "body" => "<p>Body content</p>\n",
+      "summary" => 'Summary of RAIB report',
+      "date_of_occurrence" => "2014-01-01",
+      "summary" => nil,
+      "railway_type" => "heavy-rail",
+      "railway_type_label" => "Heavy rail",
+      "report_type" => "investigation-reports",
+      "report_type_label" => "Investigation reports",
+      "updated_at" => "2014-10-24T08:41:18Z",
+      "date_of_occurrence" => "1992-04-03",
+      "published_at" => "2014-10-24T08:41:18Z",
+    }
+  )
+
+  content_api_has_an_artefact(@slug, @artefact)
+  finder_api_has_schema("raib-reports", raib_report_schema)
+end
+
+Then(/^I see the content of the RAIB report$/) do
+  expect(page).to have_content(@title)
+  check_metadata_value("Updated at", "24 October 2014")
+  check_metadata_value("Date of occurrence", "3 April 1992")
+  check_metadata_value("Railway type", "Heavy rail")
+  check_metadata_value("Report type", "Investigation report")
+end
+
+def check_metadata_value(key, value)
+  within(".metadata") do
+    expect(page).to have_content("#{key}: #{value}")
+  end
+end
+
+def raib_report_schema
+  File.read(
+    File.expand_path('../../fixtures/schemas/raib-reports.json', __FILE__)
+  )
+end


### PR DESCRIPTION
This commit adds the ability for Specialist Frontend to render RAIB reports. This contains a presenter which is called from specialist_documents_controller and a features for testing viewing RAIB reports.
