### PR TITLE
Link to the Org from a specialist document

### DIFF
--- a/app/helpers/specialist_documents_helper.rb
+++ b/app/helpers/specialist_documents_helper.rb
@@ -23,4 +23,10 @@ module SpecialistDocumentsHelper
       metadata_value(value)
     }.to_sentence(last_word_connector: ' and ').html_safe
   end
+
+  def orgs_to_sentence(organisations)
+    organisations.map { |org|
+      content_tag(:a, org.title, href: org.web_url)
+    }.to_sentence(last_word_connector: ' and ').html_safe
+  end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -29,6 +29,12 @@ class DocumentPresenter
     document.details.headers || []
   end
 
+  def organisations
+    document.tags.select{ |t| 
+      t.type = "organisation"
+    }
+  end
+
 private
 
   attr_reader :document, :schema

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -6,6 +6,11 @@
   </div>
   <div class="metadata">
     <dl class="inner-block">
+      <% if @document.organisations.any? %>
+        <dt>From:</dt>
+        <dd><%= orgs_to_sentence(@document.organisations) %></dd>
+      <% end %>
+
       <% @document.date_metadata.each do |label, date|%>
         <dt><%= label %>:</dt>
         <dd><%= nice_date_format(date) %></dd>


### PR DESCRIPTION
With certain documents, users will generally be linked straight to that document and want to know that it comes from that Org. This commit adds a `DocumentPresenter#organisations` method which pulls them from the content API response, a helper to render them as a links in a sentence and updates the view to display them.

[Ticket](https://trello.com/c/B8KLPUa6/387-drug-and-device-alerts-and-dsu-documents-should-be-tagged-to-the-mhra)

Screenshot:
![screen shot 2014-10-31 at 14 36 25](https://cloud.githubusercontent.com/assets/449004/4862286/5519a8d2-610b-11e4-961c-f646bd8e3ab1.png)
