### PR TITLE
Singularise AAIB aircraft type

### DIFF
--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -32,7 +32,7 @@ private
 
   def extra_metadata
     {
-      "Aircraft types" => aircraft_type,
+      "Aircraft type" => aircraft_type,
       "Location" => location,
       "Registration" => registration,
     }

--- a/features/step_definitions/aaib_report_steps.rb
+++ b/features/step_definitions/aaib_report_steps.rb
@@ -33,7 +33,7 @@ Then(/^I see the content of the AAIB report$/) do
   check_metadata_value("Date of occurrence", "3 April 1992")
   check_metadata_value("Aircraft category", "General aviation - fixed wing")
   check_metadata_value("Report type", "Bulletin - Pre-1997 uncategorised monthly report")
-  check_metadata_value("Aircraft types", "Grob G115")
+  check_metadata_value("Aircraft type", "Grob G115")
   check_metadata_value("Location", "Loch Muick near Ballater, Scotland")
   check_metadata_value("Registration", "G-BPKG")
 end


### PR DESCRIPTION
Aircraft types doesn't make sense when we can't pluralise this. [Ticket](http://trello.com/c/I7egEuW8/505-aaib-reports-change-the-plural-aircraft-types-to-the-singular-aircraft-type).
