### PR TITLE
Add Report a Problem link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'exception_notification', '4.0.1'
 gem 'aws-ses', '0.5.0', require: 'aws/ses'
 gem 'plek', '1.3.0'
 gem 'unicorn', '4.8.1'
-gem 'slimmer', '3.25.0'
+gem 'slimmer', '5.0.0'
 
 gem 'logstasher', '0.4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,9 +165,9 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (3.25.0)
+    slimmer (5.0.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
       plek (>= 0.1.8)
@@ -225,7 +225,7 @@ DEPENDENCIES
   rails (= 4.0.9)
   rspec-rails (= 2.14.1)
   sass-rails (~> 4.0.2)
-  slimmer (= 3.25.0)
+  slimmer (= 5.0.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.1)
   webmock (= 1.17.1)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,6 @@
 
 #wrapper {
   display: block;
-  text-align: center;
   padding-bottom: $gutter;
   border-bottom: $gutter-one-third solid $govuk-blue;
 


### PR DESCRIPTION
Bumping Slimmer to 5.0.0 gives us this link in the template. We also need to remove `text-align: center` to align it to the left properly.
