### PR TITLE
Hide updated_at if document was bulk published

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -4,6 +4,7 @@ class DocumentPresenter
   delegate :summary,
     :body,
     :published_at,
+    :bulk_published,
     to: :"document.details"
 
   def initialize(schema, document)
@@ -79,6 +80,8 @@ private
   end
 
   def default_date_metadata
+    return {} if bulk_published
+
     {
       "Updated at" => published_at,
     }

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -44,6 +44,7 @@ describe DocumentPresenter do
   let(:all_attributes) {
     filterable_attributes.merge(extra_attributes).merge({
       published_at: document_published_at,
+      bulk_published: false,
     })
   }
 


### PR DESCRIPTION
Specialist-publisher can bulk publish documents. A piece of metadata --
"bulk_published" -- is set to true when this happens.

When a document is bulk published, we don't want to show "Updated at", as this
confuses users.

Whilst this relates to https://github.com/alphagov/specialist-publisher/pull/341 it does not depend on it and can be merged in isolation.
