### PR TITLE
Reject blank dates

### DIFF
--- a/app/helpers/specialist_documents_helper.rb
+++ b/app/helpers/specialist_documents_helper.rb
@@ -30,9 +30,11 @@ module SpecialistDocumentsHelper
 
   def date_hash(date_metadata)
     hash = {}
-    date_metadata.each { |key, value|
-      hash[key] = nice_date_format(value)
-    }
+    date_metadata
+      .reject { |_, value| value.blank? }
+      .each { |key, value|
+        hash[key] = nice_date_format(value)
+      }
     hash
   end
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -19,7 +19,6 @@ class DocumentPresenter
   def date_metadata
     default_date_metadata
       .merge(extra_date_metadata)
-      .reject { |_, value| value.blank? }
   end
 
   def metadata

--- a/features/step_definitions/case_steps.rb
+++ b/features/step_definitions/case_steps.rb
@@ -17,6 +17,7 @@ Given(/^a published case$/) do
       "summary" => @summary,
       "opened_date" => "2012-01-01",
       "closed_date" => "2014-11-21",
+      "updated_at" => "",
       "case_type" => "regulatory-references-and-appeals",
       "case_state" => "closed",
       "market_sector" => "distribution-and-service-industries",
@@ -47,6 +48,7 @@ Then(/^I should see the case's content$/) do
   expect(page).to have_content("21 November 2014")
   expect(page).to have_content("Regulatory references and appeals")
   expect(page).to have_content("Closed")
+  expect(page).to have_no_content("Updated at")
 end
 
 def slug_from_title(title)

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -114,14 +114,6 @@ describe DocumentPresenter do
         })
       end
     end
-
-    context "with closed date blank" do
-      let(:document_published_at) { nil }
-
-      specify do
-        subject.date_metadata.should eq({})
-      end
-    end
   end
 
   describe "details" do


### PR DESCRIPTION
Since we now use the extra_date_metadata as a public method too, I've moved the rejection of empty dates to the helper that is used to present the nice date formats.

Also moving the test for testing this logic out of the Presenter spec and into a Cucumber.
