### PR TITLE
Exclude formats from search engines

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::SharedTemplates
-  before_filter :set_slimmer_headers
+  before_filter :set_slimmer_headers, :set_robots_headers
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -50,4 +50,20 @@ private
     end
   end
 
+  def set_robots_headers
+    if finders_excluded_from_robots.include?(request.path.split('/')[1])
+      response.headers["X-Robots-Tag"] = "none"
+    end
+  end
+
+  def finders_excluded_from_robots
+    [
+      'aaib-reports',
+      'drug-safety-update',
+      'drug-device-alerts',
+      'maib-reports',
+      'raib-reports',
+    ]
+  end
+
 end

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -34,6 +34,15 @@ describe SpecialistDocumentsController do
         assigns(:document).should be_a(AaibReportPresenter)
       end
     end
+
+    context "excluded from search engines" do
+      let(:format) { "aaib_report" }
+      let(:slug) { "aaib-reports/an-air-accident" }
+
+      it "sets the correct header" do
+        expect(response.headers["X-Robots-Tag"]).should eq("none")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
As we want to publish documents without them being "public" we exclude them from Search Engines using the same mechanism as Finder Frontend.
