### PR TITLE
Tidy up finder show page header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,7 +24,7 @@
     padding: $gutter-half 0;
 
     @include media(tablet){
-      padding: $gutter 0 $gutter*2;
+      padding: $gutter-one-third 0 $gutter;
     }
 
     .category {
@@ -42,7 +42,7 @@
 
       @include media(tablet){
         @include core-24;
-        padding: $gutter 0 0;
+        padding: $gutter*2 0 0;
       }
     }
   }
@@ -93,4 +93,3 @@
     clear: both;
   }
 }
-

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -8,10 +8,15 @@
 <% end %>
 
 <header>
-  <%= render partial: 'govuk_component/title', locals: {
-    context: link_to(@document.format_name, @document.finder_path),
-    title: @document.title
-  } %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render partial: 'govuk_component/title', locals: {
+        context: link_to(@document.format_name, @document.finder_path),
+        title: @document.title,
+        average_title_length: "long"
+      } %>
+    </div>
+  </div>
 
   <%= render partial: 'govuk_component/metadata', locals: {
     from: @document.organisations.map { |org|
@@ -56,4 +61,3 @@
     }
   } %>
 </footer>
-


### PR DESCRIPTION
This brings the presentation of the header on finder show pages more in line with other document pages on https://gov.uk.
- Adjust padding around header.
- Reduce font size of heading via component.
- Use grid to contain line length.

This takes a finder show page from this:

![screenshot_580](https://cloud.githubusercontent.com/assets/265403/5411036/cf80f20c-81f3-11e4-87f5-28806f385265.png)

...to this:

![screenshot_581](https://cloud.githubusercontent.com/assets/265403/5411040/d48cacc8-81f3-11e4-98a8-968dd46085c4.png)

(we also need to stop linking back to the finder index using the context above the heading, but that's one for another PR)
