### PR TITLE
Enable pages to be used in iframes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,10 @@ module SpecialistFrontend
     #
     # Path within public/ where assets are compiled to
     config.assets.prefix = '/specialist-frontend'
+
+    # Override Rails 4 default which restricts framing to SAMEORIGIN.
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'ALLOWALL'
+    }
   end
 end


### PR DESCRIPTION
Rails 4+ sets the X-Frame-Options header to SAMEORIGIN by default. This means
that the resource can only be put into an iframe on the same domain.

One problem this causes is that the side-by-side browser - which is a tool used
during transition - [can't work correctly](http://www.raib.gov.uk.side-by-side.alphagov.co.uk/__/#/publications/investigation_reports/reports_2014/report222014.cfm).

In the past we have decided that, with the exception of transaction start
pages, we want to allow content on GOV.UK to be iframed. Transaction start
pages are exceptional because we are particularly concerned about clickjacking
of the start button.
