### PR TITLE
Refactor duplicated Finder attrs

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -1,5 +1,10 @@
 class Finder
 
+  delegate :base_path, to: :content_item
+  delegate :beta,
+           :beta_message,
+           to: :"content_item.details"
+
   def initialize(content_item)
     @content_item = content_item
   end

--- a/app/presenters/aaib_report_presenter.rb
+++ b/app/presenters/aaib_report_presenter.rb
@@ -12,22 +12,10 @@ class AaibReportPresenter < DocumentPresenter
     "Air Accidents Investigation Branch report"
   end
 
-  def finder_path
-    "/aaib-reports"
-  end
-
   def extra_date_metadata
     {
       "Date of occurrence" => date_of_occurrence,
     }
-  end
-
-  def beta?
-    true
-  end
-
-  def beta_message
-    "Until early 2015, the <a href='http://www.aaib.gov.uk/home/index.cfm'>AAIB website</a> is the main source for AAIB reports"
   end
 
 private

--- a/app/presenters/cma_case_presenter.rb
+++ b/app/presenters/cma_case_presenter.rb
@@ -12,10 +12,6 @@ class CmaCasePresenter < DocumentPresenter
     "Competition and Markets Authority case"
   end
 
-  def finder_path
-    "/cma-cases"
-  end
-
   def extra_date_metadata
     {
       "Opened date" => opened_date,

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -17,6 +17,10 @@ class DocumentPresenter
     ""
   end
 
+  def finder_path
+    finder.base_path
+  end
+
   def date_metadata
     default_date_metadata
       .merge(extra_date_metadata)
@@ -45,11 +49,11 @@ class DocumentPresenter
   end
 
   def beta?
-    false
+    finder.beta
   end
 
   def beta_message
-    nil
+    finder.beta_message
   end
 
   def footer_date_metadata

--- a/app/presenters/maib_report_presenter.rb
+++ b/app/presenters/maib_report_presenter.rb
@@ -9,22 +9,10 @@ class MaibReportPresenter < DocumentPresenter
     "Marine Accident Investigation Branch report"
   end
 
-  def finder_path
-    "/maib-reports"
-  end
-
   def extra_date_metadata
     {
       "Date of occurrence" => date_of_occurrence,
     }
-  end
-
-  def beta?
-    true
-  end
-
-  def beta_message
-    "Until early 2015, the <a href='http://www.maib.gov.uk/home/index.cfm'>MAIB website</a> is the main source for MAIB reports"
   end
 
 private

--- a/app/presenters/medical_safety_alert_presenter.rb
+++ b/app/presenters/medical_safety_alert_presenter.rb
@@ -20,14 +20,6 @@ class MedicalSafetyAlertPresenter < DocumentPresenter
     }
   end
 
-  def beta?
-    true
-  end
-
-  def beta_message
-    "Until January 2015, <a href='http://www.mhra.gov.uk/Safetyinformation/Safetywarningsalertsandrecalls/index.htm'>the MHRA website</a> is the main source for drug alerts and medical device alerts."
-  end
-
 private
   def filterable_metadata
     {

--- a/app/presenters/raib_report_presenter.rb
+++ b/app/presenters/raib_report_presenter.rb
@@ -19,14 +19,6 @@ class RaibReportPresenter < DocumentPresenter
     }
   end
 
-  def beta?
-    true
-  end
-
-  def beta_message
-    "Until early 2015, the <a href='http://www.raib.gov.uk/home/index.cfm'>RAIB website</a> is the main source for RAIB reports"
-  end
-
 private
   def filterable_metadata
     {

--- a/spec/presenters/aaib_report_presenter_spec.rb
+++ b/spec/presenters/aaib_report_presenter_spec.rb
@@ -2,7 +2,7 @@ require "ostruct"
 require "spec_helper"
 
 describe AaibReportPresenter do
-  subject(:presenter) { AaibReportPresenter.new(schema, document) }
+  subject(:presenter) { AaibReportPresenter.new(finder, document) }
 
   let(:document) do
     double(
@@ -35,24 +35,59 @@ describe AaibReportPresenter do
     }
   }
 
-  let(:schema) { double(:schema) }
+  let(:finder) { OpenStruct.new(
+    base_path: "/aaib-reports",
+    details: OpenStruct.new(
+      beta: false,
+      beta_message: nil,
+      facets: [
+        OpenStruct.new(
+          key: "aircraft_category",
+          name: "Aircraft category",
+          allowed_values: [
+            OpenStruct.new(
+              label: "Big Aeroplanes",
+              value: "big-aeroplanes"
+            )
+          ]
+        ),
+        OpenStruct.new(
+          key: "report_type",
+          name: "Report type",
+          allowed_values: [
+            OpenStruct.new(
+              label: "a report type",
+              value: "a-report-type"
+            )
+          ]
+        ),
+      ]
+    )
+  ) }
 
-  let(:schema_response) {
+  let(:finder_response) {
     {
       "aircraft_category" => {
         label: "Aircraft category",
         values: [
-          {label: 'Big Aeroplanes', slug: "big-aeroplanes"}
+          {label: "Big Aeroplanes", slug: "big-aeroplanes"}
+        ]
+      },
+      "report_type" => {
+        label: "Report type",
+        values: [
+          {label: "a report type", slug: "a-report-type"}
         ]
       }
     }
   }
 
+
   describe "#metadata" do
     it "converts raw metadata to user friendly metadata via the schema" do
-      expect(schema).to receive(:user_friendly_values)
+      expect(finder).to receive(:user_friendly_values)
         .with(filterable_metadata)
-        .and_return(schema_response)
+        .and_return(finder_response)
 
       presenter.metadata
     end

--- a/spec/presenters/cma_case_presenter_spec.rb
+++ b/spec/presenters/cma_case_presenter_spec.rb
@@ -2,7 +2,7 @@ require "ostruct"
 require "spec_helper"
 
 describe CmaCasePresenter do
-  subject(:presenter) { CmaCasePresenter.new(schema, document) }
+  subject(:presenter) { CmaCasePresenter.new(finder, document) }
 
   let(:document) do
     double(
@@ -18,31 +18,85 @@ describe CmaCasePresenter do
 
   let(:document_details) {
     {
-      case_type: "a case type",
-      case_state: "a case state",
-      market_sector: "a market sector",
-      outcome_type: "an outcome type",
+      case_type: "ca98-and-civil-cartels",
+      market_sector: "aerospace",
+      case_state: "open",
+      outcome_type: "ca98-commitment",
     }
   }
 
-  let(:schema) { double(:schema) }
+  let(:finder) { OpenStruct.new(
+    base_path: "/cma-cases",
+    details: OpenStruct.new(
+      beta: false,
+      beta_message: nil,
+      facets: [
+        OpenStruct.new(
+          key: "case_type",
+          name: "Case type",
+          allowed_values: [
+            OpenStruct.new(
+              label: "CA98 and civil cartels",
+              value: "ca98-and-civil-cartels"
+            )
+          ]
+        ),
+        OpenStruct.new(
+          key: "market_sector",
+          name: "Market sector",
+          allowed_values: [
+            OpenStruct.new(
+              label: "Aerospace",
+              value: "aerospace"
+            )
+          ]
+        ),
+        OpenStruct.new(
+          key: "case_state",
+          name: "Case state",
+          allowed_values: [
+            OpenStruct.new(
+              label: "Open",
+              value: "open"
+            )
+          ]
+        ),
+        OpenStruct.new(
+          key: "outcome_type",
+          name: "Outcome type",
+          allowed_values: [
+            OpenStruct.new(
+              label: "CA98 commitment",
+              value: "ca98-commitment"
+            )
+          ]
+        ),
+      ]
+    )
+  ) }
 
-  let(:schema_response) {
+  let(:finder_response) {
     {
-      "foo" => {
-        label: "Foo",
+      "case_type" => {
+        label: "Case type",
         values: [
-          {label: 'The Bar', slug: "bar"}
+          {label: "CA98 and civil cartels", slug: "ca98-and-civil-cartels"}
+        ]
+      },
+      "market_sector" => {
+        label: "Market sector",
+        values: [
+          {label: "Aerospace", slug: "aerospace"}
         ]
       }
     }
   }
 
   describe "#metadata" do
-    it "converts raw metadata to user friendly metadata via the schema" do
-      expect(schema).to receive(:user_friendly_values)
+    it "converts raw metadata to user friendly metadata via the finder" do
+      expect(finder).to receive(:user_friendly_values)
         .with(document_details)
-        .and_return(schema_response)
+        .and_return(finder_response)
 
       presenter.metadata
     end


### PR DESCRIPTION
Some of the hardcoded information that we have within the presenters for each format is actually duplicated in the Finder content item. Now that we have this available we can remove this hardcoded information from each format.