### PR TITLE
Allow MHRA docs to be indexed by search engines

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -59,8 +59,6 @@ private
   def finders_excluded_from_robots
     [
       'aaib-reports',
-      'drug-safety-update',
-      'drug-device-alerts',
       'maib-reports',
       'raib-reports',
     ]


### PR DESCRIPTION
MHRA are setting up redirects for all of their content, so GOV.UK will be the sole source of this content now.