### PR TITLE
Remove document_type

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -3,7 +3,6 @@ class Finder
   delegate :base_path, to: :content_item
   delegate :beta,
            :beta_message,
-           :document_type,
            :facets,
            :format_name,
            to: :"content_item.details"

--- a/features/fixtures/finders/drug-safety-update.json
+++ b/features/fixtures/finders/drug-safety-update.json
@@ -11,7 +11,6 @@
     "beta": false,
     "beta_message": null,
     "document_noun": "update",
-    "document_type": "drug_safety_update",
     "email_signup_enabled": true,
     "format_name": "Drug Safety Update",
     "signup_link": "/government/organisations/medicines-and-healthcare-products-regulatory-agency/email-signup",

--- a/features/fixtures/finders/team-meals.json
+++ b/features/fixtures/finders/team-meals.json
@@ -11,7 +11,6 @@
     "beta": false,
     "beta_message": null,
     "document_noun": "meal",
-    "document_type": "team_meal",
     "email_signup_enabled": false,
     "facets": [
       {

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -14,7 +14,6 @@ describe SpecialistDocumentsController do
 
     before do
       allow(controller).to receive(:finder) { finder }
-      allow(finder).to receive(:document_type) { "document_type" }
       allow(controller).to receive(:content_api) { content_api }
       allow(content_api).to receive(:artefact).with(slug) { artefact }
       content_store_has_item('/aaib-reports', content_item)


### PR DESCRIPTION
We don't use this at all anymore in Specialist Frontend and it isn't in the content item anymore.