### PR TITLE
Update readme with updated dependencies and include bowl help

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,24 @@ Displays long form single page documents published via
 
 * [alphagov/static]: provides static assets (JS/CSS) and provides the GOV.UK
   templates.
-* [alphagov/finder-api]: provides the schema used to convert metadata into
+* [alphagov/content-store]: provides the finder schema used to convert metadata into
   human-readable values.
 * [alphagov/govuk_content_api]: provides the document to display.
 
 [alphagov/static]: https://github.com/alphagov/static
-[alphagov/finder-api]: https://github.com/alphagov/finder-api
+[alphagov/content-store]: https://github.com/alphagov/content-store
 [alphagov/govuk_content_api]: https://github.com/alphagov/govuk_content_api
 
 ## Running the application
 
 ```
 $ ./startup.sh
+```
+
+or you can run using bowler in the VM from cd /var/govuk/development/:
+
+```
+bowl specialist-frontend
 ```
 
 If you are using the GDS development virtual machine then the application will


### PR DESCRIPTION
In the last few weeks specialist frontend now requires content-store
as a dependency, so this has been reflected here.

I have also included brief help on bowling this app on the vm from
the development folder.

Also, I updated development to include content-store when you bowl specialist-frontend
https://github.gds/gds/development/commit/e1ae8243598a367b9639155336ab8970d4e8a547