### PR TITLE
Bump slimmer for new rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'exception_notification', '4.0.1'
 gem 'aws-ses', '0.5.0', require: 'aws/ses'
 gem 'plek', '1.3.0'
 gem 'unicorn', '4.8.1'
-gem 'slimmer', '8.2.0'
+gem 'slimmer', '8.2.1'
 
 gem 'logstasher', '0.4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.2.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -228,7 +228,7 @@ DEPENDENCIES
   rails (= 4.0.9)
   rspec-rails (= 2.14.1)
   sass-rails (~> 4.0.2)
-  slimmer (= 8.2.0)
+  slimmer (= 8.2.1)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.1)
   webmock (= 1.17.1)


### PR DESCRIPTION
This now uses the GOVUK_APP_NAME env variable rather than the
application class name so it can be cross referenced to other things in
the stack.

This contains https://github.com/alphagov/slimmer/pull/128