### PR TITLE
Add raise_value_not_found_error to Finder

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -7,6 +7,8 @@ class Finder
            :format_name,
            to: :"content_item.details"
 
+   ValueNotFoundError = Class.new(RuntimeError)
+
   def initialize(content_item)
     @content_item = content_item
   end
@@ -75,6 +77,10 @@ private
 
   def find_facet(facet_key)
     facets.find { |facet| facet.key == facet_key }
+  end
+
+  def raise_value_not_found_error(facet_key, value)
+    raise ValueNotFoundError.new("#{facet_key} value '#{value}' not found in #{base_path} content item")
   end
 
 end

--- a/spec/models/finder_spec.rb
+++ b/spec/models/finder_spec.rb
@@ -5,6 +5,7 @@ describe Finder do
   describe "#user_friendly" do
     let(:cma_cases_finder) {
       OpenStruct.new(
+        base_path: '/cma-cases',
         details: OpenStruct.new(
           facets: [
             OpenStruct.new(
@@ -82,6 +83,18 @@ describe Finder do
 
     it "doesn't alter the values if disabled (used for things without 'allowed_values', like dates)" do
       finder.user_friendly(document_attrs, change_values: false).should eq(attrs_with_expanded_keys)
+    end
+
+    let(:bad_document_attrs) {
+      {
+        case_type: "not-a-case-type",
+        market_sector: "not-a-market-sector",
+      }
+    }
+
+    it "throws an error when given incorrect document attrs" do
+      expect { finder.user_friendly(bad_document_attrs) }.
+        to raise_error(Finder::ValueNotFoundError)
     end
   end
 


### PR DESCRIPTION
When this code was copied from the API adapters, we forgot to include
this method which will raise an error if we can't find a matching label
for a value.