### PR TITLE
Switch to content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem 'webmock', '1.17.1'
   gem 'rspec-rails', '2.14.1'
   gem 'launchy'
+  gem 'govuk-content-schema-test-helpers', '1.3.0'
 end
 
 group :assets do

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 gem 'exception_notification', '4.0.1'
 gem 'aws-ses', '0.5.0', require: 'aws/ses'
-gem 'plek', '1.3.0'
+gem 'plek', '1.11.0'
 gem 'unicorn', '4.8.1'
 gem 'slimmer', '8.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.5)
+    addressable (2.3.8)
     airbrake (4.0.0)
       builder
       multi_json
@@ -89,6 +89,8 @@ GEM
       rest-client (~> 1.8.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
+    govuk-content-schema-test-helpers (1.3.0)
+      json-schema (~> 2.5.1)
     govuk_frontend_toolkit (3.0.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -103,8 +105,10 @@ GEM
       rails (>= 3.1.0)
       sprockets-rails
     json (1.8.3)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     kgio (2.8.1)
-    launchy (2.4.2)
+    launchy (2.4.3)
       addressable (~> 2.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -225,6 +229,7 @@ DEPENDENCIES
   debugger
   exception_notification (= 4.0.1)
   gds-api-adapters (= 20.1.1)
+  govuk-content-schema-test-helpers (= 1.3.0)
   govuk_frontend_toolkit (= 3.0.1)
   jasmine-rails
   launchy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,7 @@ GEM
     nokogiri (1.5.11)
     null_logger (0.0.1)
     phantomjs (1.9.7.0)
-    plek (1.3.0)
-      builder
+    plek (1.11.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -230,7 +229,7 @@ DEPENDENCIES
   jasmine-rails
   launchy
   logstasher (= 0.4.8)
-  plek (= 1.3.0)
+  plek (= 1.11.0)
   pry
   rails (= 4.1.11)
   rspec-rails (= 2.14.1)

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -4,10 +4,8 @@ class SpecialistDocumentsController < ApplicationController
   include GdsApi::Helpers
 
   def show
-    artefact = content_api.artefact(params[:path])
-
-    if artefact
-      @document = document(finder, artefact)
+    if document = content_store.content_item(base_path)
+      @document = document_presenter(finder, document)
     else
       error_not_found
     end
@@ -15,12 +13,12 @@ class SpecialistDocumentsController < ApplicationController
 
 private
 
-  def document(finder, artefact)
-    case artefact.format
+  def document_presenter(finder, document)
+    case document.format
     when "drug_safety_update"
-      DrugSafetyUpdatePresenter.new(finder, artefact)
+      DrugSafetyUpdatePresenter.new(finder, document)
     else
-      DocumentPresenter.new(finder, artefact)
+      DocumentPresenter.new(finder, document)
     end
   end
 
@@ -32,4 +30,7 @@ private
     render status: :not_found, text: "404 error not found"
   end
 
+  def base_path
+    "/#{params[:path]}"
+  end
 end

--- a/app/helpers/specialist_documents_helper.rb
+++ b/app/helpers/specialist_documents_helper.rb
@@ -21,20 +21,14 @@ module SpecialistDocumentsHelper
   end
 
   def metadata_hash(metadata)
-    hash = {}
-    metadata.each do |value|
-      hash[value.label] = metadata_values(value)
+    metadata.inject({}) do |hash, value|
+      hash.merge(value.label => metadata_values(value))
     end
-    hash
   end
 
   def date_hash(date_metadata)
-    hash = {}
-    date_metadata
-      .reject { |_, value| value.blank? }
-      .each { |key, value|
-        hash[key] = nice_date_format(value)
-      }
-    hash
+    date_metadata.inject({}) do |hash, (key, value)|
+      hash.merge(value[:label] => nice_date_format(value[:values]))
+    end
   end
 end

--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -11,13 +11,21 @@ class Finder
     @content_item = content_item
   end
 
-  def user_friendly_values(document_attributes)
+  def user_friendly(document_attributes, change_values: true)
     document_attributes.each_with_object({}) do |(k, v), values|
+      label = user_friendly_facet_label(k.to_s)
+
+      if change_values
+        value = user_friendly_facet_value(k.to_s, v)
+      else
+        value = v
+      end
+
       values.store(
         k.to_s,
         {
-          label: user_friendly_facet_label(k.to_s),
-          values: user_friendly_facet_value(k.to_s, v),
+          label: label,
+          values: value,
         }
       )
     end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,12 +1,8 @@
 class DocumentPresenter
   include SpecialistDocumentsHelper
 
-  delegate :title, :details, to: :document
-  delegate :summary,
-    :body,
-    :published_at,
-    :bulk_published,
-    to: :"document.details"
+  delegate :title, :description, :details, :public_updated_at, to: :document
+  delegate :body, :bulk_published, to: :"document.details"
 
   def initialize(finder, document)
     @finder = finder
@@ -39,7 +35,7 @@ class DocumentPresenter
 
   def date_metadata
     default_date_metadata
-      .merge(extra_date_metadata)
+      .merge(expanded_extra_date_metadata)
   end
 
   def metadata
@@ -51,13 +47,15 @@ class DocumentPresenter
   end
 
   def organisations
-    document.tags.select{ |t|
-      t.type = "organisation"
-    }
+    if links = document.links
+      links.organisations
+    else
+      []
+    end
   end
 
-  def extra_date_metadata
-    finder.date_facets.each_with_object({}) { |facet, hash| hash[facet.name] = self.send(facet.key) }
+  def expanded_extra_date_metadata
+    expand_metadata(extra_date_metadata, change_values: false)
   end
 
   def change_history
@@ -75,9 +73,9 @@ class DocumentPresenter
   def footer_date_metadata
     return {} if bulk_published
     if first_edition?
-      { published: nice_date_format(published_at) }
+      { published: nice_date_format(public_updated_at) }
     else
-      { updated: nice_date_format(published_at) }
+      { updated: nice_date_format(public_updated_at) }
     end
   end
 
@@ -110,18 +108,16 @@ private
   end
 
   def expanded_extra_metadata
-    extra_metadata
-      .reject { |_, value| value.blank? }
-      .map { |label, values| metadata_response_builder(label, values) }
-  end
-
-  def convert_filterable_metadata(expanded_filterable_metadata)
-    expanded_filterable_metadata.map { |key, data| filterable_metadata_response_builder(key, data) }
+    expand_metadata(extra_metadata, change_values: false).map { |key, data| metadata_response_builder(key, data) }
   end
 
   def expanded_filterable_metadata
-    present_metadata = filterable_metadata.reject { |_, value| value.blank? }
-    convert_filterable_metadata(finder.user_friendly_values(present_metadata))
+    expand_metadata(filterable_metadata).map { |key, data| filterable_metadata_response_builder(key, data) }
+  end
+
+  def expand_metadata(unexpanded_metadata, change_values: true)
+    present_metadata = unexpanded_metadata.reject { |_, value| value.blank? }
+    finder.user_friendly(present_metadata, change_values: change_values)
   end
 
   def default_date_metadata
@@ -129,8 +125,16 @@ private
     caption = first_edition? ? "Published" : "Updated"
 
     {
-      caption => published_at,
+      caption.downcase => {
+        label: caption,
+        values: public_updated_at,
+      }
     }
+  end
+
+  def extra_date_metadata
+    keys = finder.date_facets.map(&:key)
+    get_metadata(keys)
   end
 
   def first_edition?
@@ -138,13 +142,21 @@ private
   end
 
   def filterable_metadata
-    finder.text_facets.select(&:filterable)
-          .each_with_object({}) { |facet, hash| hash[facet.key] = self.send(facet.key) }
+    keys = finder.text_facets.select(&:filterable).map(&:key)
+    get_metadata(keys)
   end
 
   def extra_metadata
-    finder.text_facets.reject(&:filterable)
-          .each_with_object({}) { |facet, hash| hash[facet.name] = self.send(facet.key) }
+    keys = finder.text_facets.reject(&:filterable).map(&:key)
+    get_metadata(keys)
+  end
+
+  def get_metadata(keys)
+    metadata_hash.slice(*keys)
+  end
+
+  def metadata_hash
+    @metadata_hash ||= document.details.metadata.to_h.stringify_keys
   end
 
   def has_facet?(facet)

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -29,7 +29,7 @@
 
   <div class='summary'>
     <p>
-      <%= @document.summary %>
+      <%= @document.description %>
     </p>
   </div>
 </header>
@@ -49,7 +49,7 @@
 
 <footer class="js-footer">
   <%= render partial: 'govuk_component/document_footer', locals: {
-    other_dates: date_hash(@document.extra_date_metadata),
+    other_dates: date_hash(@document.expanded_extra_date_metadata),
     other: metadata_hash(@document.metadata),
     history: @document.change_history.reverse.map { |c|
       {

--- a/features/fixtures/specialist_documents/drug-safety-update.json
+++ b/features/fixtures/specialist_documents/drug-safety-update.json
@@ -1,0 +1,42 @@
+{
+  "format": "drug_safety_update",
+  "locale": "en",
+  "details" : {
+    "body" : "<p>Body content</p>\n",
+    "metadata": {
+      "therapeutic_area" : [
+        "anaesthesia-intensive-care",
+        "cancer"
+      ],
+      "document_type" : "drug_safety_update"
+    },
+    "headers" : [
+      {
+        "text" : "Reports of diabetic acidosis",
+        "level" : 2,
+        "id" : "reports-of-diabetic-acidosis"
+      },
+      {
+        "text" : "SGLT2 inhibitors – medicines in this class",
+        "level" : 2,
+        "id" : "sglt2-inhibitors--medicines-in-this-class"
+      },
+      {
+        "text" : "Further information",
+        "level" : 2,
+        "id" : "further-information"
+      }
+    ],
+    "change_note" : "",
+    "change_history" : [
+      {
+        "public_timestamp" : "2014-10-24T08:41:18Z",
+        "note" : "Published the Drug Safety Update"
+      }
+    ]
+  },
+  "base_path" : "/drug-safety-update/paracetamol-damaging-effects",
+  "description" : "Update about paracetamol",
+  "title" : "Paracetamol - Damaging effects",
+  "public_updated_at" : "2014-10-24T08:41:18Z"
+}

--- a/features/fixtures/specialist_documents/team-meal.json
+++ b/features/fixtures/specialist_documents/team-meal.json
@@ -1,0 +1,64 @@
+{
+  "format": "team-meal",
+  "locale": "en",
+  "base_path" : "/team-meals/product-gaps-team-lunch",
+  "title" : "Product Gaps Team Lunch",
+  "description" : "The CMA is investigating the anticipated acquisition relating to Compagnie Financière Richemont S.A., Yoox S.p.A and The Net-A-Porter Group Limited. ",
+  "details" : {
+    "body" : "<p>Body content</p>\n",
+    "metadata": {
+      "food": ["steak"],
+      "meal_type": "lunch",
+      "date_of_meal": "2015-02-03",
+      "location": "Moe's Tavern"
+    },
+    "headers" : [
+      {
+        "text" : "Statutory timetable",
+        "level" : 2,
+        "id" : "statutory-timetable"
+      },
+      {
+        "text" : "Phase 1",
+        "level" : 2,
+        "id" : "phase-1",
+        "headers" : [
+          {
+            "text" : "Invitation to comment: closes 24 July 2015",
+            "level" : 3,
+            "id" : "invitation-to-comment-closes-24-july-2015"
+          },
+          {
+            "text" : "Launch of undertipping inquiry",
+            "level" : 3,
+            "id" : "launch-of-undertipping-inquiry"
+          },
+          {
+            "text" : "Contact",
+            "level" : 3,
+            "id" : "contact"
+          }
+        ]
+      }
+    ],
+    "change_note" : "First published.",
+    "change_history" : [
+      {
+        "note" : "First published.",
+        "public_timestamp" : "2014-10-24T08:41:18Z"
+      }
+    ]
+  },
+  "public_updated_at" : "2014-10-24T08:41:18Z",
+  "links": {
+    "organisations": [
+      {
+        "title": "Government Digital Service",
+        "base_path": "/government/organisations/government-digital-service",
+        "api_url": "https://www.gov.uk/api/organisations/government-digital-service",
+        "web_url": "https://www.gov.uk/government/organisations/government-digital-service",
+        "locale": "en"
+      }
+    ]
+  }
+}

--- a/features/step_definitions/drug_safety_update_steps.rb
+++ b/features/step_definitions/drug_safety_update_steps.rb
@@ -1,39 +1,22 @@
 Given(/^a published drug safety update exists$/) do
-  @title = "Paracetamol - Damaging effects"
-  @slug = "drug-safety-update/#{slug_from_title(@title)}"
-  @summary = "Update about paracetamol"
-
-  @artefact = artefact_for_slug(@slug).merge(
-  "title" => @title,
-  "format" => "drug_safety_update",
-  "details" => {
-    "body" => "<p>Body content</p>\n",
-    "summary" => @summary,
-    "therapeutic_area" => ["anaesthesia-intensive-care", "cancer"],
-    "first_published_at" => "2014-10-24T08:41:18Z",
-    "change_history" => [
-      {
-        "public_timestamp" => "2014-10-24T08:41:18Z",
-        "note" => "Published the Drug Safety Update",
-      },
-    ],
-  }
-  )
-
-  content_api_has_an_artefact(@slug, @artefact)
   content_store_has_item("/drug-safety-update", drug_safety_update_finder)
+
+  @document_base_path = "/drug-safety-update/paracetamol-damaging-effects"
+  content_store_has_item(@document_base_path, drug_safety_update)
 end
 
 Then(/^I see the content of the drug safety update$/) do
-  expect(page).to have_content(@title)
-  expect(page).to have_content(@summary)
+  expect(page).to have_content("Paracetamol - Damaging effects")
+  expect(page).to have_content("Update about paracetamol")
   expect(page).to have_content("Anaesthesia and intensive care")
   expect(page).to have_content("Cancer")
   expect(page).to have_content("24 October 2014")
 end
 
+def drug_safety_update
+  read_fixture("specialist_documents/drug-safety-update.json")
+end
+
 def drug_safety_update_finder
-  File.read(
-    File.expand_path('../../fixtures/finders/drug-safety-update.json', __FILE__)
-  )
+  read_fixture("finders/drug-safety-update.json")
 end

--- a/features/support/fixture_helpers.rb
+++ b/features/support/fixture_helpers.rb
@@ -1,0 +1,9 @@
+module FixtureHelpers
+  def read_fixture(fixture_path)
+    File.read(
+      File.expand_path("../../fixtures/#{fixture_path}", __FILE__)
+    )
+  end
+end
+
+World(FixtureHelpers)

--- a/features/support/slimmer_test_mode.rb
+++ b/features/support/slimmer_test_mode.rb
@@ -1,2 +1,1 @@
 require "slimmer/test"
-

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -xe
+export DISPLAY=:99
+export GOVUK_APP_DOMAIN=test.alphagov.co.uk
+export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+env
+
+function github_status {
+  STATUS="$1"
+  MESSAGE="$2"
+  gh-status alphagov/govuk-content-schemas "$SCHEMA_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "Specialist frontend contract tests" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status failure "failed on Jenkins"
+  exit "${code}"
+}
+
+trap "error_handler ${LINENO}" ERR
+github_status pending "is running on Jenkins"
+
+# Ensure there are no artefacts left over from previous builds
+git clean -fdx
+
+# Clone govuk-content-schemas dependency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+cd tmp/govuk-content-schemas
+git checkout $SCHEMA_GIT_COMMIT
+cd ../..
+
+time bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas time bundle exec rspec spec/integration/schema_compatibility_spec.rb
+
+EXIT_STATUS=$?
+echo "EXIT STATUS: $EXIT_STATUS"
+
+if [ "$EXIT_STATUS" == "0" ]; then
+  github_status success "succeeded on Jenkins"
+else
+  github_status failure "failed on Jenkins"
+fi
+
+exit $EXIT_STATUS

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -31,7 +31,12 @@ trap "error_handler ${LINENO}" ERR
 github_status "$REPO_NAME" pending "is running on Jenkins"
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-RAILS_ENV=test bundle exec rake
+
+# Clone govuk-content-schemas depedency for tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+
+RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
 
 export EXIT_STATUS=$?
 

--- a/spec/integration/schema_compatibility_spec.rb
+++ b/spec/integration/schema_compatibility_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "gds_api/test_helpers/content_store"
+
+RSpec.describe "Schema compatibility", type: :request do
+  include GdsApi::TestHelpers::ContentStore
+
+  before do
+    GovukContentSchemaTestHelpers::Examples.new.get_all_for_format("finder").each do |finder_format|
+      content_item = JSON.parse(finder_format)
+      content_store_has_item(content_item['base_path'], content_item)
+    end
+  end
+
+  all_examples_for_supported_formats = GovukContentSchemaTestHelpers::Examples.new.get_all_for_formats(%w{
+    specialist_document
+  })
+
+  all_examples_for_supported_formats.each do |example|
+    content_item = JSON.parse(example)
+
+    it "can handle a request for #{content_item["base_path"]}" do
+      content_store_has_item(content_item['base_path'], content_item)
+
+      get content_item['base_path']
+      expect(response.status).to eq(200)
+      assert_select 'title', Regexp.new(Regexp.escape(content_item['title']))
+    end
+  end
+end

--- a/spec/models/finder_spec.rb
+++ b/spec/models/finder_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Finder do
 
-  describe "#user_friendly_values" do
+  describe "#user_friendly" do
     let(:cma_cases_finder) {
       OpenStruct.new(
         details: OpenStruct.new(
@@ -40,7 +40,7 @@ describe Finder do
       }
     }
 
-    let(:formatted_attrs) {
+    let(:attrs_with_expanded_keys_and_values) {
       {
         "case_type" => {
           :label => "Case type",
@@ -50,7 +50,7 @@ describe Finder do
               :slug => "ca98-and-civil-cartels"
             }
           ]
-        }, 
+        },
         "market_sector" => {
           :label => "Market sector",
           :values => [
@@ -63,8 +63,25 @@ describe Finder do
       }
     }
 
-    it "formats the given keys and values" do
-      finder.user_friendly_values(document_attrs).should eq(formatted_attrs)
+    let(:attrs_with_expanded_keys) {
+      {
+        "case_type" => {
+          :label => "Case type",
+          :values => "ca98-and-civil-cartels",
+        },
+        "market_sector" => {
+          :label => "Market sector",
+          :values => "aerospace",
+        }
+      }
+    }
+
+    it "formats the given keys and values by default" do
+      finder.user_friendly(document_attrs).should eq(attrs_with_expanded_keys_and_values)
+    end
+
+    it "doesn't alter the values if disabled (used for things without 'allowed_values', like dates)" do
+      finder.user_friendly(document_attrs, change_values: false).should eq(attrs_with_expanded_keys)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'webmock/rspec'
 
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,0 +1,9 @@
+require 'govuk-content-schema-test-helpers'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'frontend'
+  config.project_root = Rails.root
+end
+
+require 'govuk-content-schema-test-helpers/rspec_matchers'
+RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers

--- a/spec/support/slimmer_test_mode.rb
+++ b/spec/support/slimmer_test_mode.rb
@@ -1,0 +1,1 @@
+require "slimmer/test"


### PR DESCRIPTION
The Content API is being deprecated.

Adds contract tests to confirm that we are able to accept requests
for all specialist document examples in
https://github.com/alphagov/govuk-content-schemas

These will fail until https://github.com/alphagov/govuk-content-schemas/pull/103 is merged.

If specialist frontend starts rendering formats
other than `specialist_document` we need to add
those formats to `schema_compatibility_spec.rb`.