### PR TITLE
Show correct error on access-limited pages

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -2,6 +2,7 @@ require 'gds_api/helpers'
 
 class SpecialistDocumentsController < ApplicationController
   include GdsApi::Helpers
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   def show
     if (document = content_store.content_item(base_path)) && document.format != 'gone'
@@ -32,5 +33,9 @@ private
 
   def base_path
     "/#{params[:path]}"
+  end
+
+  def error_403(exception)
+    render text: exception.message, status: 403
   end
 end

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -16,4 +16,13 @@ describe SpecialistDocumentsController, type: :controller do
     get :show, path: path
     expect(response.status).to eq(404)
   end
+
+  it "returns 403 for access-limited item" do
+    path = 'aaib-reports/super-sekrit-document'
+    url = Plek.current.find('content-store') + "/content/" + path
+    stub_request(:get, url).to_return(status: 403, headers: {})
+
+    get :show, path: path
+    expect(response.status).to eq(403)
+  end
 end

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe SpecialistDocumentsController, type: :controller do
+  it "gets item from content store" do
+    stub_specialist_document
+    stub_finder
+
+    get :show, path: "aaib-report/plane-took-off-by-mistake"
+    expect(assigns["document"].title).to eq("The plane took off by mistake")
+  end
+
+  it "returns 404 for item not in content store" do
+    path = 'government/case-studies/boost-chocolate-production'
+    content_store_does_not_have_item('/' + path)
+
+    get :show, path: path
+    expect(response.status).to eq(404)
+  end
+end

--- a/spec/support/specialist_documents.rb
+++ b/spec/support/specialist_documents.rb
@@ -1,0 +1,30 @@
+require 'gds_api/test_helpers/content_store'
+
+module SpecialistDocumentHelpers
+  include GdsApi::TestHelpers::ContentStore
+
+  def stub_specialist_document
+    base_path = "/aaib-report/plane-took-off-by-mistake"
+    content_store_has_item(base_path, {
+      base_path: base_path,
+      title: "The plane took off by mistake",
+      format: "specialist_document",
+      public_updated_at: Time.zone.now,
+      details: {
+        metadata: {
+          document_type: "aaib_report"
+        }
+      }
+    })
+  end
+
+  def stub_finder
+    base_path = "/aaib-report"
+    content_store_has_item(base_path, {
+      base_path: base_path,
+      format: "finder"
+    })
+  end
+end
+
+RSpec.configuration.include SpecialistDocumentHelpers


### PR DESCRIPTION
Pass the 403 error from content-store downstream so that static renders the nice "not permitted" page.