### PR TITLE
Remove sticky navs from the specialist document pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,8 +3,4 @@
 
 $(function(){
   GOVUK.primaryLinks.init('.primary-item');
-
-  if (typeof ieVersion === 'undefined' || ieVersion > 6) {
-    GOVUK.stickAtTopWhenScrolling.init();
-  }
 });

--- a/app/assets/stylesheets/_stick-at-top-when-scrolling.scss
+++ b/app/assets/stylesheets/_stick-at-top-when-scrolling.scss
@@ -1,7 +1,0 @@
-.content-fixed {
-  position: fixed;
-  top: 0;
-}
-.shim {
-  display: block;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,6 @@
 @import "css3";
 
 @import "reset";
-@import "stick-at-top-when-scrolling";
 
 #wrapper {
   padding-bottom: $gutter;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,9 +3,9 @@
   <head>
     <title><%= yield(:page_title) %> - GOV.UK</title>
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %> <script>var ieVersion = 6;</script> <![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %> <script>var ieVersion = 7;</script> <![endif]-->
-    <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %> <script>var ieVersion = 8;</script> <![endif]-->
+    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><![endif]-->
+    <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><![endif]-->
+    <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
   </head>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -35,7 +35,7 @@
 </header>
 <div class="grid-row">
   <nav class="column-third sidebar">
-    <ol class="js-stick-at-top-when-scrolling">
+    <ol>
       <%= render 'nav_item', headings: @document.headers %>
     </ol>
   </nav>
@@ -47,7 +47,7 @@
   </div>
 </div>
 
-<footer class="js-footer">
+<footer>
   <%= render partial: 'govuk_component/document_footer', locals: {
     other_dates: date_hash(@document.expanded_extra_date_metadata),
     other: metadata_hash(@document.metadata),


### PR DESCRIPTION
Once the nav is longer than the viewport height it’s impossible to see the bottom of it, unless you scroll right to the end of the page.

This PR removes the functionality, and a set of associated workarounds and styling.

(@markhurrell OKed this removal and asked that @alextea be kept in the loop)