### PR TITLE
Configure asset host in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,5 +25,7 @@ SpecialistFrontend::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 end


### PR DESCRIPTION
When run under `govuk_setenv`, this configures the asset host to point
at the assets-origin on the dev VM.  This will give us better dev-prod
parity, and enable running this behind the router in dev.

See equiv on `frontend`:

alphagov/frontend@77bb2cb

I removed the manual setting of asset host `STATIC_DEV`, as this isn't
required and will work without - falling back. This is the way other apps
work, and @edds, who added it, is confident it's fine to remove

--

As with https://github.com/alphagov/finder-frontend/pull/235, there are quite a few others apps missing this config and that will have the same problem. We should look at cleaning them all up / adding this config to the template rails apps, but in the mean time this unblocks @robmckinnon demoing tribunals using the `router` locally.