### PR TITLE
Fix bulk_published bug in DocumentPresenter

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -2,7 +2,7 @@ class DocumentPresenter
   include SpecialistDocumentsHelper
 
   delegate :title, :description, :details, :public_updated_at, to: :document
-  delegate :body, :bulk_published, to: :"document.details"
+  delegate :body, to: :"document.details"
 
   def initialize(finder, document)
     @finder = finder
@@ -77,6 +77,10 @@ class DocumentPresenter
     else
       { updated: nice_date_format(public_updated_at) }
     end
+  end
+
+  def bulk_published
+    document.details.metadata["bulk_published"]
   end
 
 private

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -30,13 +30,14 @@ describe DocumentPresenter do
   let(:document_details) {
     double(:document_details,
       metadata: metadata,
-      bulk_published: false,
       change_history: [],
     )
   }
 
   let(:metadata) {
-    filterable_attributes.merge(extra_attributes).merge(date_attributes)
+    filterable_attributes.merge(extra_attributes).merge(date_attributes).merge(
+      bulk_published: false
+    )
   }
 
   let(:filterable_attributes) {
@@ -241,6 +242,12 @@ describe DocumentPresenter do
     it "returns an empty array if there is no headers in the details hash" do
       allow(document_details).to receive(:headers) { nil }
       expect(subject.headers).to eq([])
+    end
+  end
+
+  describe "bulk_published" do
+    it "returns the value of bulk_published" do
+      expect(subject.bulk_published).to eq false
     end
   end
 end


### PR DESCRIPTION
Bulk_published was not directly accessible under document.details,
as it is wrapped in a metadata hash. 

With this fix, DocumentPresenter can now access
the bulk_published value and display the publication date when appropriate.

This will help with this [Trello story](https://trello.com/c/bwQBZbMK/101-suppress-publication-date-on-aaib-report-small) too about hiding the publication date for an AAIB report from 1987.

cc @boffbowsh @jamiecobbett 