### PR TITLE
Remove 'exception_notification' and 'ses' gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ else
   gem 'gds-api-adapters', '20.1.1'
 end
 
-gem 'exception_notification', '4.0.1'
-gem 'aws-ses', '0.5.0', require: 'aws/ses'
 gem 'plek', '1.11.0'
 gem 'unicorn', '4.8.1'
 gem 'slimmer', '8.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,11 +33,6 @@ GEM
       builder
       multi_json
     arel (5.0.1.20140414130214)
-    aws-ses (0.5.0)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -72,9 +67,6 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    exception_notification (4.0.1)
-      actionmailer (>= 3.0.4)
-      activesupport (>= 3.0.4)
     execjs (2.0.2)
     gds-api-adapters (20.1.1)
       link_header
@@ -203,7 +195,6 @@ GEM
     webmock (1.17.1)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
-    xml-simple (1.1.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -212,11 +203,9 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.0.0)
-  aws-ses (= 0.5.0)
   better_errors
   binding_of_caller
   cucumber-rails (= 1.4.0)
-  exception_notification (= 4.0.1)
   gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_frontend_toolkit (= 3.0.1)


### PR DESCRIPTION
They don't appear to be used, since the app uses Airbrake to integrate
with Errbit.

/cc @jamiecobbett @boffbowsh @binaryberry 