### PR TITLE
Upgrade Slimmer, don't explicitly set 'core_layout'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'exception_notification', '4.0.1'
 gem 'aws-ses', '0.5.0', require: 'aws/ses'
 gem 'plek', '1.11.0'
 gem 'unicorn', '4.8.1'
-gem 'slimmer', '8.4.0'
+gem 'slimmer', '9.0.0'
 
 gem 'logstasher', '0.4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0)
-    slimmer (8.4.0)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -231,7 +231,7 @@ DEPENDENCIES
   rails (= 4.1.11)
   rspec-rails (= 2.14.1)
   sass-rails (~> 4.0.2)
-  slimmer (= 8.4.0)
+  slimmer (= 9.0.0)
   uglifier (>= 1.3.0)
   unicorn (= 4.8.1)
   webmock (= 1.17.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,7 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::SharedTemplates
-  before_filter :set_slimmer_headers
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-private
-  def set_slimmer_headers
-    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "core_layout"
-  end
 end


### PR DESCRIPTION
This has no effect on how the app runs, the same template will be used.

Slimmer 9.0.0 switched to core_layout as it's default layout option,
as it's the modern/recommend option. Apps explicitly setting a
layout should be outliers we plan on fixing.

Not setting the layout if we don't need to will make those outliers
easier to identify and simplifies the app controller code.