### PR TITLE
Clean up whitespace at bottom of page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,11 +8,6 @@
 @import "reset";
 
 #wrapper {
-  padding-bottom: $gutter;
-
-  @include media(desktop) {
-    padding-bottom: $gutter*2;
-  }
 
   #page {
     @extend %contain-floats;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,8 @@
       text-decoration:none;
     }
 
+    // Use a wider dt width to accommodate longer
+    // labels, eg "Date of occurrence:"
     .govuk-metadata {
       dt {
         min-width: 134px;


### PR DESCRIPTION
* Stop the “report a problem” link from floating too high above the footer
* Clarify purpose of a govuk-component override

(An upcoming change to the default margins on the document-footer component in static will increase the gap between report a problem and the footer to 45px to make that gap consistent)

# Before
![screen shot 2016-02-08 at 16 01 11](https://cloud.githubusercontent.com/assets/319055/12890880/753d59b6-ce7d-11e5-9fd0-02b15370d32a.png)

# After
![screen shot 2016-02-08 at 16 04 41](https://cloud.githubusercontent.com/assets/319055/12890935/afd6c490-ce7d-11e5-8e17-93ede5879a20.png)

