### PR TITLE
Alter margins in preparation for component margin updates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,17 +31,20 @@
     }
 
     .govuk-metadata {
+      // Temporary margin addition.
+      // Should be removed once this default margin has been
+      // added to the component itself.
+      margin-bottom: $gutter * 1.5;
+
       dt {
         min-width: 134px;
       }
     }
     .summary {
       @include core-19;
-      padding: $gutter/2 0 0;
 
       @include media(tablet){
         @include core-24;
-        padding: $gutter*2 0 0;
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,10 +20,10 @@
 
   header {
     @extend %contain-floats;
-    padding: $gutter-half 0;
+    padding-bottom: $gutter-half;
 
-    @include media(tablet){
-      padding: $gutter-one-third 0 $gutter;
+    @include media(tablet) {
+      padding-bottom: $gutter;
     }
 
     .category {


### PR DESCRIPTION
* We’re adding a default margin to the bottom of the `govuk-metadata` component (https://github.com/alphagov/static/commit/cd57d931c648fc1f72a3c45fad96c29371a1898a). If that were to go live as-is, then that margin would double up with the summary’s padding. Before we deploy the change to the metadata component we need to remove the summary padding and add a temporary margin bottom so that everything looks correct between deploys.
* Remove unnecessary padding-top styles above header. The title component provides a top margin. No other vertical spacing is needed between the banner and the title.

This must be merged and deployed before https://github.com/alphagov/static/pull/730