### PR TITLE
Remove govuk-metadata override

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,11 +28,6 @@
     // Use a wider dt width to accommodate longer
     // labels, eg "Date of occurrence:"
     .govuk-metadata {
-      // Temporary margin addition.
-      // Should be removed once this default margin has been
-      // added to the component itself.
-      margin-bottom: $gutter * 1.5;
-
       dt {
         min-width: 134px;
       }


### PR DESCRIPTION
This should be merged once https://github.com/alphagov/static/pull/730 is deployed

* Remove govuk-metadata override. These margins are provided by default in static.