### PR TITLE
Set cache time from content item max_cache_time value

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -3,7 +3,6 @@ require 'gds_api/helpers'
 class SpecialistDocumentsController < ApplicationController
   include GdsApi::Helpers
   rescue_from GdsApi::HTTPForbidden, with: :error_403
-  DEFAULT_CACHE_TIME = 10
 
   def show
     if (document = content_store.content_item(base_path)) && document.format != 'gone'
@@ -26,7 +25,7 @@ private
   end
 
   def cache_time(document)
-    document['details']['max_cache_time'] || DEFAULT_CACHE_TIME
+    document['details']['max_cache_time'] || DEFAULT_CACHE_TIME_IN_SECONDS
   end
 
   def finder

--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -3,9 +3,11 @@ require 'gds_api/helpers'
 class SpecialistDocumentsController < ApplicationController
   include GdsApi::Helpers
   rescue_from GdsApi::HTTPForbidden, with: :error_403
+  DEFAULT_CACHE_TIME = 10
 
   def show
     if (document = content_store.content_item(base_path)) && document.format != 'gone'
+      expires_in(cache_time(document), public: true)
       @document = document_presenter(finder, document)
     else
       error_not_found
@@ -21,6 +23,10 @@ private
     else
       DocumentPresenter.new(finder, document)
     end
+  end
+
+  def cache_time(document)
+    document['details']['max_cache_time'] || DEFAULT_CACHE_TIME
   end
 
   def finder

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,5 +1,9 @@
 require 'gds_api/base'
 
+DEFAULT_CACHE_TIME_IN_SECONDS=10
+
+GdsApi::Base.default_options = { cache_ttl: DEFAULT_CACHE_TIME_IN_SECONDS }
+
 if Rails.env.development?
   GdsApi::Base.default_options = { disable_cache: true }
 end

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -7,6 +7,15 @@ describe SpecialistDocumentsController, type: :controller do
 
     get :show, path: "aaib-report/plane-took-off-by-mistake"
     expect(assigns["document"].title).to eq("The plane took off by mistake")
+    expect(response.cache_control[:max_age]).to eq(30)
+  end
+
+  it "gets item from content store without max cache time and sets default cache time" do
+    stub_specialist_document_without_max_cache_time
+    stub_finder
+
+    get :show, path: "aaib-report/plane-took-off-by-mistake"
+    expect(response.cache_control[:max_age]).to eq(10)
   end
 
   it "returns 404 for item not in content store" do

--- a/spec/support/specialist_documents.rb
+++ b/spec/support/specialist_documents.rb
@@ -13,7 +13,23 @@ module SpecialistDocumentHelpers
       details: {
         metadata: {
           document_type: "aaib_report"
-        }
+        },
+        max_cache_time: 30
+      }
+    })
+  end
+
+  def stub_specialist_document_without_max_cache_time
+    base_path = "/aaib-report/plane-took-off-by-mistake"
+    content_store_has_item(base_path, {
+      base_path: base_path,
+      title: "The plane took off by mistake",
+      format: "specialist_document",
+      public_updated_at: Time.zone.now,
+      details: {
+       metadata: {
+         document_type: "aaib_report",
+       },
       }
     })
   end


### PR DESCRIPTION
- When citizens receive email notifications, the website needs to serve
fresh content. This change allows setting a cache times from the publishing app.
If max_cache_time isn't set, the default is 10 seconds.
- [Trello Card](https://trello.com/c/WGlWkWT5/70-reduce-cache-on-specialist-publisher-medium)