### PR TITLE
Add breadcrumbs to specialist content

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -1,6 +1,6 @@
 class Finder
 
-  delegate :base_path, :links, to: :content_item
+  delegate :base_path, :title, :links, to: :content_item
   delegate :beta,
            :beta_message,
            :facets,

--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -1,0 +1,14 @@
+module Breadcrumbs
+  def breadcrumbs
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: finder_name,
+        url: finder_path,
+      },
+    ]
+  end
+end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,5 +1,6 @@
 class DocumentPresenter
   include SpecialistDocumentsHelper
+  include Breadcrumbs
 
   delegate :title, :description, :details, :public_updated_at, to: :document
   delegate :body, to: :"document.details"
@@ -23,6 +24,10 @@ class DocumentPresenter
     else
       super
     end
+  end
+
+  def finder_name
+    finder.title
   end
 
   def format_name

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,3 @@
+<% if @document.breadcrumbs.any? %>
+  <%= render 'govuk_component/breadcrumbs', breadcrumbs: @document.breadcrumbs %>
+<% end %>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -10,8 +10,8 @@
 <header>
   <div class="grid-row">
     <div class="column-two-thirds">
+      <%= render "shared/breadcrumbs" %>
       <%= render partial: 'govuk_component/title', locals: {
-        context: link_to(@document.format_name, @document.finder_path),
         title: @document.title,
         average_title_length: "long"
       } %>

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -13,6 +13,7 @@ Then(/^I see the content of the Document$/) do
   check_metadata_value("Meal type", "Lunch")
   check_metadata_value("Food", "Steak")
   check_metadata_value("Location", "Moe's Tavern")
+  check_breadcrumb_value("GOV.UK Team meals", "/team-meals")
 end
 
 Given(/^a published Document with a major change exists$/) do
@@ -22,6 +23,7 @@ end
 Then(/^I see the content of the republished Document$/) do
   expect(page).to have_content("Product Gaps Team Lunch")
   check_metadata_value("Updated", "24 October 2014")
+  check_breadcrumb_value("GOV.UK Team meals", "/team-meals")
 end
 
 def slug_from_title(title)

--- a/features/step_definitions/drug_safety_update_steps.rb
+++ b/features/step_definitions/drug_safety_update_steps.rb
@@ -11,6 +11,7 @@ Then(/^I see the content of the drug safety update$/) do
   expect(page).to have_content("Anaesthesia and intensive care")
   expect(page).to have_content("Cancer")
   expect(page).to have_content("24 October 2014")
+  check_breadcrumb_value("Drug Safety Update", "/drug-safety-update")
 end
 
 def drug_safety_update

--- a/features/support/fixture_helpers.rb
+++ b/features/support/fixture_helpers.rb
@@ -4,6 +4,13 @@ module FixtureHelpers
       File.expand_path("../../fixtures/#{fixture_path}", __FILE__)
     )
   end
+
+  def check_breadcrumb_value(title, url)
+    within(shared_component_selector('breadcrumbs')) do
+      expect(page).to have_content(title)
+      expect(page).to have_content(url)
+    end
+  end
 end
 
 World(FixtureHelpers)

--- a/spec/models/finder_spec.rb
+++ b/spec/models/finder_spec.rb
@@ -6,6 +6,7 @@ describe Finder do
     let(:cma_cases_finder) {
       OpenStruct.new(
         base_path: '/cma-cases',
+        title: 'Competition and Markets Authority cases',
         details: OpenStruct.new(
           facets: [
             OpenStruct.new(

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -10,6 +10,7 @@ describe DocumentPresenter do
   let(:finder) {
     OpenStruct.new(
       base_path: "/finder",
+      title: "Finder documents",
       format_name: "Finder",
       facets: facets,
       date_facets: date_facets,
@@ -248,6 +249,22 @@ describe DocumentPresenter do
   describe "bulk_published" do
     it "returns the value of bulk_published" do
       expect(subject.bulk_published).to eq false
+    end
+  end
+
+  describe "breadcrumbs" do
+    it "returns the breadcrumbs for the document" do
+      breadcrumbs_array = [
+        {
+          "title": "Home",
+          "url": "/",
+        },
+        {
+          "title": "Finder documents",
+          "url": "/finder",
+        },
+      ]
+      expect(subject.breadcrumbs).to eq(breadcrumbs_array)
     end
   end
 end


### PR DESCRIPTION
Specialist frontend currently displays documents with a single link above the page title, linking to the parent finder. This commit replaces that link with a breadcrumb, using GOV.UK components. It links to the GOV.UK home page, and also the parent finder for the specified document, using the name of the finder as the link title.

Trello: https://trello.com/c/8rd14IVP/34-add-breadcrumb-for-specialist-content-3

Before:

![screen shot 2016-08-08 at 12 49 54](https://cloud.githubusercontent.com/assets/444232/17478920/19e2c000-5d67-11e6-89e8-aaeade9fffde.png)

After:
![screen shot 2016-08-08 at 12 50 07](https://cloud.githubusercontent.com/assets/444232/17478924/1efb8f36-5d67-11e6-9c9d-34777b596367.png)
