### PR TITLE
Check both format and document_type for 'gone'

### DIFF
--- a/app/controllers/specialist_documents_controller.rb
+++ b/app/controllers/specialist_documents_controller.rb
@@ -8,8 +8,9 @@ class SpecialistDocumentsController < ApplicationController
   def show
     document = content_store.content_item(base_path)
 
-    if document['format'] != 'gone'
+    if document
       expires_in(cache_time(document), public: true)
+      render_gone and return if gone?(document)
       @document = document_presenter(finder, document)
     else
       error_not_found
@@ -28,7 +29,8 @@ private
   end
 
   def cache_time(document)
-    document['details']['max_cache_time'] || DEFAULT_CACHE_TIME_IN_SECONDS
+    details = document['details'] || {}
+    details['max_cache_time'] || DEFAULT_CACHE_TIME_IN_SECONDS
   end
 
   def finder
@@ -45,5 +47,13 @@ private
 
   def error_403(exception)
     render plain: exception.message, status: 403
+  end
+
+  def render_gone
+    render text: "", status: 410
+  end
+
+  def gone?(document)
+    document['format'] == 'gone' || document['document_type'] == 'gone'
   end
 end

--- a/spec/controllers/specialist_documents_controller_spec.rb
+++ b/spec/controllers/specialist_documents_controller_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe SpecialistDocumentsController, type: :controller do
     expect(response.status).to eq(404)
   end
 
+  it "returns 410 for an item that exists, but has a format of 'gone'" do
+    stub_unpublished_specialist_document(format: "gone", document_type: nil)
+    stub_finder
+
+    get :show, path: "aaib-report/plane-took-off-by-mistake"
+    expect(response.status).to eq(410)
+  end
+
+  it "returns 410 for an item that exists, but has a document_type of 'gone'" do
+    stub_unpublished_specialist_document
+    stub_finder
+
+    get :show, path: "aaib-report/plane-took-off-by-mistake"
+    expect(response.status).to eq(410)
+  end
+
   it "returns 403 for access-limited item" do
     path = 'aaib-reports/super-sekrit-document'
     url = Plek.current.find('content-store') + "/content/" + path

--- a/spec/support/specialist_documents.rb
+++ b/spec/support/specialist_documents.rb
@@ -19,6 +19,14 @@ module SpecialistDocumentHelpers
     })
   end
 
+  def stub_unpublished_specialist_document(attributes = {})
+    base_path = "/aaib-report/plane-took-off-by-mistake"
+    content_store_has_item(base_path, {
+      base_path: base_path,
+      document_type: "gone",
+    }.merge(attributes))
+  end
+
   def stub_specialist_document_without_max_cache_time
     base_path = "/aaib-report/plane-took-off-by-mistake"
     content_store_has_item(base_path, {


### PR DESCRIPTION
Previously, we only looked at the format field, which
meant that documents with a 'gone' document_type were
breaking. The frontend assumed they were specialist
documents and tried to render them.

Note that the 410 page is actually rendered by static:

https://github.com/alphagov/govuk-puppet/blob/66b13345f82ed986378a7b1c88fdc1d953a41425/modules/router/templates/router_include.conf.erb#L87

https://github.com/alphagov/static/blob/63b06de629ca4bf3e7916d2ddd881380499a21bf/app/views/root/410.html.erb