### PR TITLE
Use gov.uk rather than co.uk for the test domains

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.alphagov.co.uk
-export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+export GOVUK_APP_DOMAIN=test.alphagov.gov.uk
+export GOVUK_ASSET_ROOT=http://static.test.alphagov.gov.uk
 env
 
 function github_status {

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.alphagov.gov.uk
-export GOVUK_ASSET_ROOT=http://static.test.alphagov.gov.uk
 env
 
 function github_status {

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -x
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.gov.uk
-export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 export REPO_NAME="alphagov/specialist-frontend"
 env
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 ENV["RAILS_ENV"] ||= 'test'
+ENV["GOVUK_APP_DOMAIN"] ||= 'test.gov.uk'
+ENV["GOVUK_ASSET_ROOT"] ||= 'http://static.test.gov.uk'
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'slimmer/rspec'


### PR DESCRIPTION
It seems as though the schema compatibility tests for specialist-frontend broke recently.

Here is an example broken build: https://ci.dev.publishing.service.gov.uk/job/govuk_specialist_frontend_schema_tests/983/consoleFull

The `.co.uk` gtld does not match the [test helpers in slimmer](https://github.com/alphagov/slimmer/blob/868095a99fdf559cdad80b9102d882322214bc60/lib/slimmer/test_helpers/shared_templates.rb) which stub out requests to static.

I haven't gone into why this used to work before so I'm not sure this PR is a good idea but [at least one other project](https://github.com/alphagov/manuals-frontend/blob/master/jenkins.sh) uses a `.gov.uk` extension.

The worry is that it was `.co.uk` for a reason to avoid using [the stubs](https://github.com/alphagov/slimmer/blob/868095a99fdf559cdad80b9102d882322214bc60/lib/slimmer/test_helpers/shared_templates.rb)?