### PR TITLE
Fix schema tests

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.alphagov.co.uk
-export GOVUK_ASSET_ROOT=http://static.test.alphagov.co.uk
+export GOVUK_APP_DOMAIN=test.gov.uk
+export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env
 
 function github_status {


### PR DESCRIPTION
This script uses different env variables from the main jenkins.sh scripts, so it always fails for govuk-content-schemas PRs. This makes the vars the same.