### PR TITLE
Notify Airbrake when facet pairs aren't found

### DIFF
--- a/app/models/finder.rb
+++ b/app/models/finder.rb
@@ -65,7 +65,9 @@ private
       }
 
     if value_label_pair.nil?
-      raise_value_not_found_error(facet_key, value)
+      err = ValueNotFoundError.new("#{facet_key} value '#{value}' not found in #{base_path} content item")
+      Airbrake.notify_or_ignore(err)
+      value
     else
       value_label_pair.label
     end
@@ -78,9 +80,4 @@ private
   def find_facet(facet_key)
     facets.find { |facet| facet.key == facet_key }
   end
-
-  def raise_value_not_found_error(facet_key, value)
-    raise ValueNotFoundError.new("#{facet_key} value '#{value}' not found in #{base_path} content item")
-  end
-
 end

--- a/spec/models/finder_spec.rb
+++ b/spec/models/finder_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe Finder do
       }
     }
 
-    it "throws an error when given incorrect document attrs" do
-      expect { finder.user_friendly(bad_document_attrs) }.
-        to raise_error(Finder::ValueNotFoundError)
+    it "sends an error via Airbrake when given incorrect document attrs" do
+      expect(Airbrake).to receive(:notify_or_ignore).twice.with(Finder::ValueNotFoundError)
+      finder.user_friendly(bad_document_attrs)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/yd1F33zV/250-fix-9-broken-dfid-documents

Currently we raise an exception when finder facet data doesn't match anything
in the document metadata. Instead we should notify Airbrake and simply return
the value so that the frontend doesn't respond with 500.

I ran this branch locally and the value renders when the facet pair isn't found (KY in this case):
![screenshot from 2016-08-17 15 27 36](https://cloud.githubusercontent.com/assets/93511/17740094/45feed38-648f-11e6-9024-a057155d1e28.png)
