### PR TITLE
Add meta description tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
+    <% if content_for(:meta_description).present? %>
+      <meta name="description" content="<%= content_for(:meta_description) %>" />
+    <% end %>
   </head>
 
   <body>
@@ -19,4 +22,3 @@
     </main>
   </body>
 </html>
-

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, [@document.title, @document.format_name].join(' ') %>
+<% content_for :meta_description, @document.description %>
 <% if @document.beta? %>
   <% if @document.beta_message %>
     <%= render partial: 'govuk_component/beta_label', locals: { message: @document.beta_message } %>


### PR DESCRIPTION
This commit adds meta description tags to all pages, the contents of which are set to the description associated with the page. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them