### PR TITLE
Return empty array when finder is missing organisation links

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -52,11 +52,7 @@ class DocumentPresenter
   end
 
   def organisations
-    if links = finder.links
-      links.organisations
-    else
-      []
-    end
+    finder.try(:links).try(:organisations) || []
   end
 
   def expanded_extra_date_metadata

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -267,4 +267,45 @@ RSpec.describe DocumentPresenter do
       expect(subject.breadcrumbs).to eq(breadcrumbs_array)
     end
   end
+
+  describe "organisations" do
+    let(:links) do
+      [
+        OpenStruct.new(content_id: SecureRandom.uuid),
+        OpenStruct.new(content_id: SecureRandom.uuid),
+      ]
+    end
+
+    context "when the finder has organisations links" do
+      before do
+        finder.links = OpenStruct.new(
+          organisations: links,
+        )
+      end
+
+      it "it returns the finder links" do
+        expect(subject.organisations).to be(finder.links.organisations)
+      end
+    end
+
+    context "when the finder has links but no organisations ones" do
+      before do
+        finder.links = OpenStruct.new(
+          different_links: links,
+        )
+      end
+
+      it "returns an empty array" do
+        expect(subject.organisations).to be_empty
+      end
+    end
+
+    context "when the finder has no links" do
+      before { finder.links = nil }
+
+      it "returns an empty array" do
+        expect(subject.organisations).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prior to this the presence of a finders links meant whatever value of organisations was returned, which could be nil. This would then error when this value was mapped.