### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -32,7 +32,7 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without devel
 
 # Clone govuk-content-schemas depedency for tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 RAILS_ENV=test GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake
 


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Specialist Frontend app that
don't work with the currently deployed govuk-content-schemas (this
changes comes from GOV.UK RFC 59).