### PR TITLE
add startup live flag so you can use live content-store and static

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,21 @@ Displays long form single page documents published via
 [alphagov/static]: https://github.com/alphagov/static
 [alphagov/content-store]: https://github.com/alphagov/content-store
 
-## Running the application
+### Running the application
 
 ```
-$ ./startup.sh
+./startup.sh
 ```
+
+The app should start on http://localhost:3065 or
+http://specialist-frontend.dev.gov.uk on GOV.UK development machines.
+
+```
+./startup.sh --live
+```
+
+This will run the app and point it at the production GOV.UK `content-store` and `static` instances.
+
 
 or you can run using bowler in the VM from cd /var/govuk/development/:
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3065
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
+  PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
+  bundle exec rails s -p 3065
+else
+  bundle exec rails s -p 3065
+fi


### PR DESCRIPTION
this is to keep consistent with government-frontend, ideally all apps should have this, so it's consistent across the apps

https://github.com/alphagov/government-frontend/blob/e24743b47271ffbb5fffa0625f028b45a0d701e2/startup.sh#L1-L14

