### PR TITLE
Move to new ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,6 @@ end
 group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0'
+  gem 'govuk-lint'
+  gem 'ci_reporter_rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       builder
       multi_json
     arel (7.1.1)
+    ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -58,6 +59,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     crack (0.4.3)
@@ -97,6 +103,9 @@ GEM
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
+    govuk-lint (1.2.1)
+      rubocop (~> 0.39.0)
+      scss_lint
     govuk_frontend_toolkit (3.0.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -134,8 +143,11 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     null_logger (0.0.1)
+    parser (2.3.3.1)
+      ast (~> 2.2)
     pkg-config (1.1.7)
     plek (1.12.0)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -174,12 +186,17 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.1)
     raindrops (0.17.0)
     rake (11.2.2)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
     rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -197,6 +214,13 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -205,6 +229,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scss_lint (0.52.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     slimmer (9.5.0)
       activesupport
       json
@@ -231,6 +258,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
+    unicode-display_width (1.1.3)
     unicorn (4.8.1)
       kgio (~> 2.6)
       rack
@@ -252,9 +280,11 @@ DEPENDENCIES
   airbrake (~> 4.0)
   better_errors
   binding_of_caller
+  ci_reporter_rspec
   cucumber-rails
   gds-api-adapters (~> 33.0)
   govuk-content-schema-test-helpers (= 1.3.0)
+  govuk-lint
   govuk_frontend_toolkit (= 3.0.1)
   launchy
   logstasher (= 0.4.8)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,99 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'specialist-frontend'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'specialist-frontend',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
+  try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Clean up workspace") {
+      govuk.cleanupGit()
+    }
+
+    stage("git merge") {
+      govuk.mergeMasterBranch()
+    }
+
+    stage("Configure Rails environment") {
+      govuk.setEnvar("RAILS_ENV", "test")
+    }
+
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage("bundle install") {
+      govuk.bundleApp()
+    }
+
+    stage("rubylinter") {
+      govuk.rubyLinter("app test lib")
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    stage("Run tests") {
+      govuk.runRakeTask("ci:setup:rspec default")
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}")
+    }
+
+    stage("Deploy to integration") {
+      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+    }
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'ci/reporter/rake/rspec'
 
 SpecialistFrontend::Application.load_tasks
 


### PR DESCRIPTION
Trello: https://trello.com/c/la8hgBCR/583-move-specialist-frontend-to-new-ci-infrastructure-1

The old CI infrastructure is in the process of being wound down so we need to move our apps to the new one.