### PR TITLE
Track contents clicks

### DIFF
--- a/app/views/specialist_documents/_nav_item.html.erb
+++ b/app/views/specialist_documents/_nav_item.html.erb
@@ -1,11 +1,17 @@
+<% heading_level ||= 2 %>
 <% headings.each do |heading| %>
-   <li>
-     <a href='#<%= heading['id'] %>'><%= heading['text'] %></a>
-       <% if heading['headers'].present? %>
-         <ol class="dash-list">
-           <%= render 'nav_item', headings: heading['headers'] %>
-         </ol>
-       <% end %>
+  <li>
+    <a
+      href="#<%= heading['id']%>"
+      data-track-category="contentsClicked"
+      data-track-action="leftColumnH<%= heading_level %>"
+      data-track-label="<%= heading['id']%>">
+      <%= heading['text'] %>
+    </a>
+    <% if heading['headers'].present? %>
+      <ol class="dash-list">
+        <%= render 'nav_item', headings: heading['headers'], heading_level: heading_level + 1 %>
+      </ol>
+    <% end %>
    </li>
 <% end %>
-

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -35,7 +35,7 @@
   </div>
 </header>
 <div class="grid-row">
-  <nav class="column-third sidebar">
+  <nav class="column-third sidebar" data-module="track-click">
     <ol>
       <%= render 'nav_item', headings: @document.headers %>
     </ol>


### PR DESCRIPTION
* Match government-frontend category, action and label
* Increment heading_level each time partial gets nested, to allow tracking of H2, H3 and H4
* Fix 3-space whitespace

Goes with https://github.com/alphagov/government-frontend/pull/235
Part of https://trello.com/c/62Gy8pyj/77-track-interactions-with-contents-lists-1-s

Example clicks tracked:
![screen shot 2017-02-06 at 10 53 15](https://cloud.githubusercontent.com/assets/319055/22644458/8fffde44-ec5a-11e6-9313-5f36402d625b.png)

@nickcolley 
