### PR TITLE
Remove trailing colons from contents lists

### DIFF
--- a/app/helpers/specialist_documents_helper.rb
+++ b/app/helpers/specialist_documents_helper.rb
@@ -31,4 +31,8 @@ module SpecialistDocumentsHelper
       hash.merge(value[:label] => nice_date_format(value[:values]))
     end
   end
+
+  def strip_trailing_colons(heading)
+    heading.gsub(/\:$/, '')
+  end
 end

--- a/app/views/specialist_documents/_nav_item.html.erb
+++ b/app/views/specialist_documents/_nav_item.html.erb
@@ -6,7 +6,7 @@
       data-track-category="contentsClicked"
       data-track-action="leftColumnH<%= heading_level %>"
       data-track-label="<%= heading['id']%>">
-      <%= heading['text'] %>
+      <%= strip_trailing_colons(heading['text']) %>
     </a>
     <% if heading['headers'].present? %>
       <ol class="dash-list">


### PR DESCRIPTION
* Matches government-frontend: https://github.com/alphagov/government-frontend/pull/225
* The colon may make sense in the body of content, but it’s incorrect in a list of contents

## Before
![screen shot 2017-02-07 at 10 46 53](https://cloud.githubusercontent.com/assets/319055/22688125/cb1ca39a-ed22-11e6-8b00-43472d7a963b.png)

## After
![screen shot 2017-02-07 at 10 46 40](https://cloud.githubusercontent.com/assets/319055/22688127/cd4757c8-ed22-11e6-86c2-f9c5830a06f4.png)