### PR TITLE
Fix rspec required error in Production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'ci/reporter/rake/rspec'
+require 'ci/reporter/rake/rspec' unless Rails.env.production?
 
 SpecialistFrontend::Application.load_tasks
 


### PR DESCRIPTION
Trello: https://trello.com/c/la8hgBCR/583-move-specialist-frontend-to-new-ci-infrastructure-1

We don't need rspec gem in production.