### PR TITLE
Add get started button

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "shims";
 @import "typography";
 @import "css3";
+@import "design-patterns/buttons";
 
 @import "reset";
 
@@ -38,6 +39,53 @@
       @include media(tablet){
         @include core-24;
       }
+    }
+  }
+
+  // We might think about adding this to govuk_frontend_toolkit or as a
+  // component in static if other apps will also be using it.
+  // Things we are doing over and above the button mixin:
+  //  * Adding a right-facing chevron icon
+  //  * Making the button larger with more padding and a larger font
+  //    size since it is the main content on the page
+  // These styles make the button look the same as it did before
+  // buisness finance support schemes were migrated.
+  .get-started {
+    .button {
+      @include button;
+      @include bold-24($line-height: (16 / 24));
+      padding: 0.60em 1.7em 0.45em 0.67em;
+      background-image: image-url("icon-pointer.png");
+      background-position: 100% 50%;
+      background-repeat: no-repeat;
+
+      @include media(mobile) {
+        background-position: 110% 50%;
+      }
+
+      @include ie(7) {
+        padding: 0.45em 1.7em 0.62em 0.67em;
+      }
+
+      @include ie(6) {
+        background-image: image-url("icon-pointer-indexed.png");
+        padding: 0.45em 0.5em 0.62em 0em;
+      }
+
+      @include device-pixel-ratio() {
+        background-image: image-url("icon-pointer-2x.png");
+        background-size: 30px 19px;
+      }
+    }
+
+    // This is some text that appears below the button to describe where
+    // the button leads to (for example, "on gov.uk").
+    .destination {
+      @include core-14;
+      color: $text-colour;
+      display: block;
+      margin-top: 0.5em;
+      max-width: 13em;
     }
   }
 


### PR DESCRIPTION
This commit adds support for a get started button which will be used by migrated business finance support scheme documents. The button uses the basic button styles from `govuk_frontend_toolkit` plus extra styles from `static`.

Trello: https://trello.com/c/wtra9q0T/486-add-support-for-green-start-button-into-specialist-frontend-specialist-publisher

![screen shot 2017-02-20 at 13 31 13](https://cloud.githubusercontent.com/assets/444232/23126937/ee5c22ec-f770-11e6-890d-94d8a490bbcc.png)
