### PR TITLE
Add "find out more" button

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -1,0 +1,59 @@
+// Buttons
+// ==========================================================================
+
+$focus-colour: #ffbf47;
+
+// Return ems from a pixel value
+// This assumes a base of 19px
+@function em($px, $base: 19) {
+  @return ($px / $base) + em;
+}
+
+.button {
+  @include button ($button-colour);
+  @include box-sizing (border-box);
+  vertical-align: top;
+
+  @include media (mobile) {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+// Fix unwanted button padding in Firefox
+.button::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.button:focus {
+  outline: 3px solid $focus-colour;
+}
+
+// Disabled buttons
+.button[disabled="disabled"] {
+  background: $button-colour;
+}
+
+.button[disabled="disabled"]:focus {
+  outline: none;
+}
+
+// Start now buttons
+.button-start,
+.button-get-started {
+  @include bold-24;
+  background-image: file-url("icon-pointer.png");
+  background-repeat: no-repeat;
+  background-position: 100% 50%;
+  padding: em(7) em(41) em(4) em(16);
+
+  @include device-pixel-ratio {
+    background-image: file-url("icon-pointer-2x.png");
+    background-size: 30px 19px;
+  }
+
+  @include ie(6) {
+    background-image: file-url("icon-pointer-2x.png");
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,8 +4,10 @@
 @import "shims";
 @import "typography";
 @import "css3";
+@import "design-patterns/buttons";
 
 @import "reset";
+@import "buttons";
 
 #wrapper {
 
@@ -39,6 +41,16 @@
         @include core-24;
       }
     }
+  }
+
+  // This is some text that appears below the "find out more" button to
+  // describe where the button leads to (for example, "on gov.uk").
+  .find-out-more-destination {
+    @include core-14;
+    color: $text-colour;
+    display: block;
+    margin-top: 0.5em;
+    max-width: 13em;
   }
 
   .sidebar {

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -84,6 +84,14 @@ class DocumentPresenter
     document.details.metadata["bulk_published"]
   end
 
+  def continuation_link
+    document.details.metadata["continuation_link"]
+  end
+
+  def will_continue_on
+    document.details.metadata["will_continue_on"]
+  end
+
 private
 
   attr_reader :document, :finder

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -45,6 +45,10 @@
     <%= render partial: 'govuk_component/govspeak', locals: {
       content: @document.body.html_safe
     } %>
+    <% if @document.continuation_link %>
+      <a class="button button-start" href="<%= @document.continuation_link %>" role="button">Find out more</a>
+      <span class="find-out-more-destination"><%= @document.will_continue_on %></span>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
This commit adds support for a “find out more” button which will be initially used by migrated business finance support scheme documents but can also be used by other specialist document types in future. The button copies the start button styles from `govuk-element` to prevent a new dependency.

Trello: https://trello.com/c/wtra9q0T/486-add-support-for-green-start-button-into-specialist-frontend

![screencapture-dev-gov-uk-business-finance-support-test-1487863677466](https://cloud.githubusercontent.com/assets/444232/23265522/d2aabedc-f9dc-11e6-88d2-54c6ac43b1d3.png)

cc: @nickcolley 