### PR TITLE
Configurable log path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module SpecialistFrontend
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
+
+    config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
   end
 end


### PR DESCRIPTION
This makes it relatively easy to have a differently name draft log file for
when two instances of this app are running in docker containers.