### PR TITLE
Use the correct branch for schemas when running as a schema test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ node {
     }
 
     stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 


### PR DESCRIPTION
When a PR is raised against content schemas, we want to run the deployed-to-production branch of specialist-frontend against the branch of the PR in schemas - which comes in as the SCHEMA_BRANCH environment variable.

The contentSchemaDependency method will check out the `deployed-to-production` branch of schemas by default, unless the the SCHEMA_BRANCH is passed on as an argument.