### PR TITLE
Track standard content item analytics

### DIFF
--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -26,6 +26,10 @@ class DocumentPresenter
     end
   end
 
+  def content_item
+    document
+  end
+
   def finder_name
     finder.title
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
     <% if content_for(:meta_description).present? %>
       <meta name="description" content="<%= content_for(:meta_description) %>" />
     <% end %>
+    <%= content_for(:head) %>
   </head>
 
   <body>

--- a/app/views/specialist_documents/show.html.erb
+++ b/app/views/specialist_documents/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for :page_title, [@document.title, @document.format_name].join(' ') %>
 <% content_for :meta_description, @document.description %>
+<% content_for :head do %>
+  <%= render partial: "govuk_component/analytics_meta_tags",
+    locals: { content_item: @document.content_item } %>
+<% end %>
 <% if @document.beta? %>
   <% if @document.beta_message %>
     <%= render partial: 'govuk_component/beta_label', locals: { message: @document.beta_message } %>


### PR DESCRIPTION
Add govuk meta tags to each specialist document page. This enables Google Analytics tracking of some content item properties like the document type and linked organisations.

The main reason for this change is to track the document type (which is tracked in the `govuk:format` meta tag against GA dimension 2). The ranking of service standard reports (which are specialist documents) is going to be changed in the search results, and this extra tracking will help us analyse whether the changes to search have helped users find the content they're looking for.

https://trello.com/c/gCeAhOCh/57-make-service-standard-reports-less-prominent-and-misleading-in-search-results